### PR TITLE
Fix r_g_q_results_formatter_factory() to produce the result advertised ...

### DIFF
--- a/src/rasqal_result_formats.c
+++ b/src/rasqal_result_formats.c
@@ -172,7 +172,7 @@ rasqal_get_query_results_formatter_factory(rasqal_world* world,
       factory_flags |= RASQAL_QUERY_RESULTS_FORMAT_FLAG_WRITER;
 
     /* Flags must match */
-    if(flags && factory_flags != flags)
+    if(flags && (factory_flags & flags) != flags)
       continue;
 
     if(!name && !uri)


### PR DESCRIPTION
... in 130fa835

If reader _or_ writer is requested and the format in question supports both
return the formatter factory.

(rasqal_get_query_results_formatter_factory): query reader and writer flags
individually instead of insisting on total equality.
