### PR TITLE
new rasqal_query_execute2(), old API deprecated

### DIFF
--- a/docs/rasqal-docs.xml
+++ b/docs/rasqal-docs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN" 
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
                "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd" [
 <!ENTITY version SYSTEM "version.xml">
 ]>
@@ -80,9 +80,10 @@ execution plans and execute the queries into query result sets.
       which comprehensively describes every class and function of the API.
       </para>
     </partintro>
-      
+
     <xi:include href="xml/section-general.xml"/>
     <xi:include href="xml/section-data.xml"/>
+    <xi:include href="xml/section-data-sets.xml"/>
     <xi:include href="xml/section-expression.xml"/>
     <xi:include href="xml/section-graph_pattern.xml"/>
     <xi:include href="xml/section-literal.xml"/>

--- a/docs/rasqal-sections.txt
+++ b/docs/rasqal-sections.txt
@@ -54,6 +54,18 @@ rasqal_data_graph_print
 </SECTION>
 
 <SECTION>
+<FILE>section-data-sets</FILE>
+rasqal_data_graphs_set_new
+rasqal_free_data_graphs_set
+rasqal_data_graphs_set_add_data_graph
+rasqal_data_graphs_set_add_data_graphs
+rasqal_data_graphs_set_get_data_graph_sequence
+rasqal_data_graphs_get_graphs_count
+rasqal_data_graphs_set_get_data_graph
+rasqal_data_graphs_set_dataset_contains_named_graph
+</SECTION>
+
+<SECTION>
 <FILE>section-expression</FILE>
 rasqal_expression
 rasqal_expression_flags

--- a/docs/tmpl/rasqal-unused.sgml
+++ b/docs/tmpl/rasqal-unused.sgml
@@ -1,0 +1,74 @@
+<!-- ##### USER_FUNCTION bind_match ##### -->
+<para>
+
+</para>
+
+@rtm: 
+@user_data: 
+@bindings: 
+@parts: 
+@Returns: 
+
+<!-- ##### USER_FUNCTION finish ##### -->
+<para>
+
+</para>
+
+@rtm: 
+@user_data: 
+
+<!-- ##### USER_FUNCTION free_triples_source ##### -->
+<para>
+
+</para>
+
+@user_data: 
+
+<!-- ##### USER_FUNCTION init_triples_match ##### -->
+<para>
+
+</para>
+
+@rtm: 
+@rts: 
+@user_data: 
+@m: 
+@t: 
+@Returns: 
+
+<!-- ##### USER_FUNCTION is_end ##### -->
+<para>
+
+</para>
+
+@rtm: 
+@user_data: 
+@Returns: 
+
+<!-- ##### USER_FUNCTION next_match ##### -->
+<para>
+
+</para>
+
+@rtm: 
+@user_data: 
+
+<!-- ##### USER_FUNCTION support_feature ##### -->
+<para>
+
+</para>
+
+@user_data: 
+@feature: 
+@Returns: 
+
+<!-- ##### USER_FUNCTION triple_present ##### -->
+<para>
+
+</para>
+
+@rts: 
+@user_data: 
+@t: 
+@Returns: 
+

--- a/docs/tmpl/section-data-sets.sgml
+++ b/docs/tmpl/section-data-sets.sgml
@@ -1,0 +1,97 @@
+<!-- ##### SECTION Title ##### -->
+Data Graph Sets
+
+<!-- ##### SECTION Short_Description ##### -->
+Sets of RDF data graphs.
+
+<!-- ##### SECTION Long_Description ##### -->
+<para>
+These objects are containers of zero or more data graphs.
+</para>
+
+<!-- ##### SECTION See_Also ##### -->
+<para>
+
+</para>
+
+<!-- ##### SECTION Stability_Level ##### -->
+
+
+<!-- ##### SECTION Image ##### -->
+
+
+<!-- ##### FUNCTION rasqal_data_graphs_set_new ##### -->
+<para>
+
+</para>
+
+@void: 
+@Returns: 
+
+
+<!-- ##### FUNCTION rasqal_free_data_graphs_set ##### -->
+<para>
+
+</para>
+
+@set: 
+
+
+<!-- ##### FUNCTION rasqal_data_graphs_set_add_data_graph ##### -->
+<para>
+
+</para>
+
+@set: 
+@data_graph: 
+@Returns: 
+
+
+<!-- ##### FUNCTION rasqal_data_graphs_set_add_data_graphs ##### -->
+<para>
+
+</para>
+
+@set: 
+@data_graphs: 
+@Returns: 
+
+
+<!-- ##### FUNCTION rasqal_data_graphs_set_get_data_graph_sequence ##### -->
+<para>
+
+</para>
+
+@set: 
+@Returns: 
+
+
+<!-- ##### FUNCTION rasqal_data_graphs_get_graphs_count ##### -->
+<para>
+
+</para>
+
+@set: 
+@Returns: 
+
+
+<!-- ##### FUNCTION rasqal_data_graphs_set_get_data_graph ##### -->
+<para>
+
+</para>
+
+@set: 
+@idx: 
+@Returns: 
+
+
+<!-- ##### FUNCTION rasqal_data_graphs_set_dataset_contains_named_graph ##### -->
+<para>
+
+</para>
+
+@set: 
+@graph_uri: 
+@Returns: 
+
+

--- a/docs/tmpl/section-unused.sgml
+++ b/docs/tmpl/section-unused.sgml
@@ -48,97 +48,28 @@ Unused
 
 
 
-<!-- ##### USER_FUNCTION bind_match ##### -->
-<para>
-
-</para>
-
-@rtm: 
-@user_data: 
-@bindings: 
-@parts: 
-@Returns: 
-
-
-<!-- ##### USER_FUNCTION finish ##### -->
-<para>
-
-</para>
-
-@rtm: 
-@user_data: 
-
-
-<!-- ##### USER_FUNCTION free_triples_source ##### -->
-<para>
-
-</para>
-
-@user_data: 
-
-
-<!-- ##### USER_FUNCTION init_triples_match ##### -->
-<para>
-
-</para>
-
-@rtm: 
-@rts: 
-@user_data: 
-@m: 
-@t: 
-@Returns: 
-
-
-<!-- ##### USER_FUNCTION is_end ##### -->
-<para>
-
-</para>
-
-@rtm: 
-@user_data: 
-@Returns: 
-
-
-<!-- ##### USER_FUNCTION next_match ##### -->
-<para>
-
-</para>
-
-@rtm: 
-@user_data: 
-
-
 <!-- ##### STRUCT rasqal_expression_s ##### -->
 <para>
 
 </para>
 
+@world: 
+@usage: 
+@op: 
+@arg1: 
+@arg2: 
+@arg3: 
+@literal: 
+@value: 
+@name: 
+@args: 
+@params: 
+@flags: 
+@arg4: 
 
 <!-- ##### TYPEDEF rasqal_random ##### -->
 <para>
 
 </para>
-
-
-<!-- ##### USER_FUNCTION support_feature ##### -->
-<para>
-
-</para>
-
-@user_data: 
-@feature: 
-@Returns: 
-
-
-<!-- ##### USER_FUNCTION triple_present ##### -->
-<para>
-
-</para>
-
-@rts: 
-@user_data: 
-@t: 
-@Returns: 
 
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,21 +4,21 @@
 #
 # Copyright (C) 2003-2010, David Beckett http://www.dajobe.org/
 # Copyright (C) 2003-2005, University of Bristol, UK http://www.bristol.ac.uk/
-# 
+#
 # This package is Free Software and part of Redland http://librdf.org/
-# 
+#
 # It is licensed under the following three licenses as alternatives:
 #   1. GNU Lesser General Public License (LGPL) V2.1 or any newer version
 #   2. GNU General Public License (GPL) V2 or any newer version
 #   3. Apache License, V2.0 or any newer version
-# 
+#
 # You may not use this file except in compliance with at least one of
 # the above three licenses.
-# 
+#
 # See LICENSE.html or LICENSE.txt at the top of this package for the
 # complete terms and further detail along with the license texts for
 # the licenses in COPYING.LIB, COPYING and LICENSE-2.0.txt respectively.
-# 
+#
 
 bin_SCRIPTS = rasqal-config
 lib_LTLIBRARIES = librasqal.la
@@ -110,7 +110,7 @@ rasqal_row_compatible.c rasqal_format_table.c rasqal_query_write.c \
 rasqal_format_json.c rasqal_format_sv.c rasqal_format_html.c \
 rasqal_format_rdf.c \
 rasqal_rowsource_assignment.c rasqal_update.c \
-rasqal_triple.c rasqal_data_graph.c rasqal_prefix.c \
+rasqal_triple.c rasqal_data_graph.c rasqal_data_graphs_set.c rasqal_prefix.c \
 rasqal_solution_modifier.c rasqal_projection.c rasqal_bindings.c \
 rasqal_service.c \
 rasqal_dataset.c \

--- a/src/rasqal.h.in
+++ b/src/rasqal.h.in
@@ -1416,6 +1416,8 @@ int rasqal_data_graphs_set_add_data_graphs(rasqal_data_graphs_set* set, raptor_s
 RASQAL_API
 raptor_sequence* rasqal_data_graphs_set_get_data_graph_sequence(rasqal_data_graphs_set* set);
 RASQAL_API
+int rasqal_data_graphs_get_graphs_count(rasqal_data_graphs_set* set);
+RASQAL_API
 rasqal_data_graph* rasqal_data_graphs_set_get_data_graph(rasqal_data_graphs_set* set, int idx);
 RASQAL_API
 int rasqal_data_graphs_set_dataset_contains_named_graph(rasqal_data_graphs_set* set, raptor_uri *graph_uri);

--- a/src/rasqal.h.in
+++ b/src/rasqal.h.in
@@ -1373,8 +1373,7 @@ int rasqal_query_prepare(rasqal_query* query, const unsigned char *query_string,
 RASQAL_API
 rasqal_query_results* rasqal_query_execute(rasqal_query* query);
 RASQAL_API
-rasqal_query_results*
-rasqal_query_execute2(rasqal_query* query, raptor_sequence* data_graphs);
+rasqal_query_results* rasqal_query_execute2(rasqal_query* query, raptor_sequence* data_graphs);
 
 RASQAL_API
 void* rasqal_query_get_user_data(rasqal_query* query);

--- a/src/rasqal.h.in
+++ b/src/rasqal.h.in
@@ -1407,7 +1407,7 @@ rasqal_query_results_type rasqal_query_get_result_type(rasqal_query* query);
 RASQAL_API
 rasqal_data_graphs_set *rasqal_data_graphs_set_new(void);
 RASQAL_API
-void rasqal_data_graphs_set_free(rasqal_data_graphs_set* set);
+void rasqal_free_data_graphs_set(rasqal_data_graphs_set* set);
 RASQAL_API
 int rasqal_data_graphs_set_add_data_graph(rasqal_data_graphs_set* set, rasqal_data_graph* data_graph);
 RASQAL_API

--- a/src/rasqal.h.in
+++ b/src/rasqal.h.in
@@ -405,6 +405,11 @@ typedef struct {
 
 /**
  * rasqal_data_graphs_set:
+ *
+ * A set of data graphs.
+ *
+ * In the current implementation the set is ordered, but this may change
+ * in a future version.
  */
 typedef struct rasqal_data_graphs_set_s rasqal_data_graphs_set;
 

--- a/src/rasqal.h.in
+++ b/src/rasqal.h.in
@@ -404,6 +404,12 @@ typedef struct {
 
 
 /**
+ * rasqal_data_graphs_set:
+ */
+typedef struct rasqal_data_graphs_set_s rasqal_data_graphs_set;
+
+
+/**
  * rasqal_literal_type:
  * @RASQAL_LITERAL_BLANK: RDF blank node literal (SPARQL r:bNode)
  * @RASQAL_LITERAL_URI: RDF URI Literal (SPARQL r:URI)
@@ -1244,16 +1250,16 @@ int rasqal_query_get_offset(rasqal_query* query);
 RASQAL_API
 void rasqal_query_set_offset(rasqal_query* query, int offset);
 
-RASQAL_API
+RASQAL_API RASQAL_DEPRECATED
 int rasqal_query_add_data_graph(rasqal_query* query, rasqal_data_graph* data_graph);
-RASQAL_API
+RASQAL_API RASQAL_DEPRECATED
 int rasqal_query_add_data_graphs(rasqal_query* query, raptor_sequence* data_graphs);
 
-RASQAL_API
+RASQAL_API RASQAL_DEPRECATED
 raptor_sequence* rasqal_query_get_data_graph_sequence(rasqal_query* query);
-RASQAL_API
+RASQAL_API RASQAL_DEPRECATED
 rasqal_data_graph* rasqal_query_get_data_graph(rasqal_query* query, int idx);
-RASQAL_API
+RASQAL_API RASQAL_DEPRECATED
 int rasqal_query_dataset_contains_named_graph(rasqal_query* query, raptor_uri *graph_uri);
 
 RASQAL_API
@@ -1370,7 +1376,7 @@ int rasqal_query_print(rasqal_query* query, FILE* fh);
 /* Query */
 RASQAL_API
 int rasqal_query_prepare(rasqal_query* query, const unsigned char *query_string, raptor_uri *base_uri);
-RASQAL_API
+RASQAL_API RASQAL_DEPRECATED
 rasqal_query_results* rasqal_query_execute(rasqal_query* query);
 RASQAL_API
 rasqal_query_results* rasqal_query_execute2(rasqal_query* query, raptor_sequence* data_graphs);
@@ -1390,6 +1396,24 @@ RASQAL_API
 rasqal_row* rasqal_query_get_bindings_row(rasqal_query* query, int idx);
 RASQAL_API
 rasqal_query_results_type rasqal_query_get_result_type(rasqal_query* query);
+
+/* data graphs sets */
+
+RASQAL_API
+rasqal_data_graphs_set *rasqal_data_graphs_set_new(void);
+RASQAL_API
+void rasqal_data_graphs_set_free(rasqal_data_graphs_set* set);
+RASQAL_API
+int rasqal_data_graphs_set_add_data_graph(rasqal_data_graphs_set* set, rasqal_data_graph* data_graph);
+RASQAL_API
+int rasqal_data_graphs_set_add_data_graphs(rasqal_data_graphs_set* set, raptor_sequence* data_graphs);
+
+RASQAL_API
+raptor_sequence* rasqal_data_graphs_set_get_data_graph_sequence(rasqal_data_graphs_set* set);
+RASQAL_API
+rasqal_data_graph* rasqal_data_graphs_set_get_data_graph(rasqal_data_graphs_set* set, int idx);
+RASQAL_API
+int rasqal_data_graphs_set_dataset_contains_named_graph(rasqal_data_graphs_set* set, raptor_uri *graph_uri);
 
 /* query results */
 RASQAL_API

--- a/src/rasqal.h.in
+++ b/src/rasqal.h.in
@@ -4,21 +4,21 @@
  *
  * Copyright (C) 2003-2010, David Beckett http://www.dajobe.org/
  * Copyright (C) 2003-2005, University of Bristol, UK http://www.bristol.ac.uk/
- * 
+ *
  * This package is Free Software and part of Redland http://librdf.org/
- * 
+ *
  * It is licensed under the following three licenses as alternatives:
  *   1. GNU Lesser General Public License (LGPL) V2.1 or any newer version
  *   2. GNU General Public License (GPL) V2 or any newer version
  *   3. Apache License, V2.0 or any newer version
- * 
+ *
  * You may not use this file except in compliance with at least one of
  * the above three licenses.
- * 
+ *
  * See LICENSE.html or LICENSE.txt at the top of this package for the
  * complete terms and further detail along with the license texts for
  * the licenses in COPYING.LIB, COPYING and LICENSE-2.0.txt respectively.
- * 
+ *
  */
 
 
@@ -328,7 +328,7 @@ struct rasqal_expression_s;
  * @value: Variable value or NULL if unbound.
  * @offset: Internal.
  * @type: Variable type.
- * @expression: Expression when the variable is a computed SELECT expression 
+ * @expression: Expression when the variable is a computed SELECT expression
  * @user_data: Pointer to user data associated with a variable.  This is not used by rasqal.
  * @usage: reference count
  *
@@ -380,7 +380,7 @@ typedef enum {
  * @base_uri: base URI for reading from iostream
  * @usage: usage count of this object
  *
- * A source of RDF data for querying. 
+ * A source of RDF data for querying.
  *
  * If @iostr is present, the graph can be constructed by parsing the
  * iostream and using @base_uri as a base uri. Otherwise the graph
@@ -435,7 +435,7 @@ typedef struct {
  *
  * which corresponds to in enum values
  *
- *   BLANK << URI << STRING << 
+ *   BLANK << URI << STRING <<
  *     (BOOLEAN | INTEGER | DOUBLE | FLOAT | DECIMAL | DATETIME | XSD_STRING)
  *
  *     (RASQAL_LITERAL_FIRST_XSD ... RASQAL_LITERAL_LAST_XSD)
@@ -593,7 +593,7 @@ struct rasqal_literal_s {
   /* UTF-8 string, pattern, qname, blank, double, float, decimal, datetime */
   const unsigned char *string;
   unsigned int string_len;
-  
+
   union {
     /* integer and boolean types */
     int integer;
@@ -683,7 +683,7 @@ struct rasqal_literal_s {
  * @RASQAL_EXPR_GROUP_CONCAT: Expression for LAQRS GROUP_CONCAT(arglist) aggregate function
  * @RASQAL_EXPR_SAMPLE: Expression for LAQRS SAMPLE(expr) aggregate function
  * @RASQAL_EXPR_IN: Expression for LAQRS expr IN ( list of expr )
- * @RASQAL_EXPR_NOT_IN: Expression for LAQRS expr NOT IN ( list of expr ) 
+ * @RASQAL_EXPR_NOT_IN: Expression for LAQRS expr NOT IN ( list of expr )
  * @RASQAL_EXPR_ISNUMERIC: Expression for SPARQL 1.1 isNUMERIC(expr)
  * @RASQAL_EXPR_YEAR: Expression for SPARQL 1.1 YEAR(datetime)
  * @RASQAL_EXPR_MONTH: Expression for SPARQL 1.1 MONTH(datetime)
@@ -865,7 +865,7 @@ struct rasqal_expression_s {
   rasqal_world* world;
 
   int usage;
-  
+
   rasqal_op op;
 
   struct rasqal_expression_s* arg1;
@@ -923,7 +923,7 @@ typedef enum {
 /**
  * rasqal_generate_bnodeid_handler:
  * @world: world arg
- * @user_data: user data given to 
+ * @user_data: user data given to
  * @user_bnodeid: user blank node ID string passed in
  *
  * User handler used with rasqal_world_set_generate_bnodeid_handler() to set method for generating a blank node ID.
@@ -935,7 +935,7 @@ typedef unsigned char* (*rasqal_generate_bnodeid_handler)(rasqal_world* world, v
 
 /**
  * rasqal_query_verb:
- * @RASQAL_QUERY_VERB_SELECT: SPARQL query select verb. 
+ * @RASQAL_QUERY_VERB_SELECT: SPARQL query select verb.
  * @RASQAL_QUERY_VERB_CONSTRUCT: SPARQL query construct verb.
  * @RASQAL_QUERY_VERB_DESCRIBE: SPARQL query describe verb.
  * @RASQAL_QUERY_VERB_ASK: SPARQL query ask verb.
@@ -1372,6 +1372,9 @@ RASQAL_API
 int rasqal_query_prepare(rasqal_query* query, const unsigned char *query_string, raptor_uri *base_uri);
 RASQAL_API
 rasqal_query_results* rasqal_query_execute(rasqal_query* query);
+RASQAL_API
+rasqal_query_results*
+rasqal_query_execute2(rasqal_query* query, raptor_sequence* data_graphs);
 
 RASQAL_API
 void* rasqal_query_get_user_data(rasqal_query* query);
@@ -1876,7 +1879,7 @@ char* rasqal_regex_replace(rasqal_world* world, raptor_locator* locator, const c
  * Rasqal SPARQL Protocol Service
  */
 typedef struct rasqal_service_s rasqal_service;
-  
+
 RASQAL_API
 rasqal_service* rasqal_new_service(rasqal_world* world, raptor_uri* service_uri, const unsigned char* query_string, raptor_sequence* data_graphs);
 RASQAL_API
@@ -1926,7 +1929,7 @@ typedef enum {
  * @finish: Finish triples match and destroy any allocated memory.
  * @is_exact: non-0 if triple to match is all literal constants
  * @finished: >0 if the match has finished
- * 
+ *
  * Triples match structure as initialised by #rasqal_triples_source
  * method init_triples_match.
  */
@@ -2003,7 +2006,7 @@ typedef enum {
   RASQAL_TRIPLES_SOURCE_FEATURE_NONE,
   RASQAL_TRIPLES_SOURCE_FEATURE_IOSTREAM_DATA_GRAPH
 } rasqal_triples_source_feature;
-  
+
 
 /**
  * rasqal_triples_source:
@@ -2019,7 +2022,7 @@ typedef enum {
  */
 struct rasqal_triples_source_s {
   int version;
-  
+
   rasqal_query* query;
 
   void *user_data;
@@ -2089,7 +2092,7 @@ typedef void (*rasqal_triples_error_handler2)(rasqal_world* world, raptor_locato
  */
 typedef struct {
   int version;
-  
+
   void *user_data;
   size_t user_data_size;
 
@@ -2100,14 +2103,14 @@ typedef struct {
   /* API v3 onwards */
   int (*init_triples_source2)(rasqal_world* world, raptor_sequence* data_graphs, void *factory_user_data, void *user_data, rasqal_triples_source *rts, rasqal_triples_error_handler2 handler, unsigned int flags);
 } rasqal_triples_source_factory;
-  
+
 
 /**
  * rasqal_triples_source_factory_register_fn:
  * @factory: factory to register
  *
  * Register a factory for generating triples sources #rasqal_triples_source
- * 
+ *
  * Return value: non-0 on failure
  */
 typedef int (*rasqal_triples_source_factory_register_fn)(rasqal_triples_source_factory *factory);
@@ -2182,7 +2185,7 @@ int rasqal_set_triples_source_factory(rasqal_world* world, rasqal_triples_source
  * next_match:
  * @rtm: triples match context
  * @user_data: user data
- * 
+ *
  * Internal - see #rasqal_triples_match
  */
 

--- a/src/rasqal.h.in
+++ b/src/rasqal.h.in
@@ -1384,7 +1384,7 @@ int rasqal_query_prepare(rasqal_query* query, const unsigned char *query_string,
 RASQAL_API RASQAL_DEPRECATED
 rasqal_query_results* rasqal_query_execute(rasqal_query* query);
 RASQAL_API
-rasqal_query_results* rasqal_query_execute2(rasqal_query* query, raptor_sequence* data_graphs);
+rasqal_query_results* rasqal_query_execute2(rasqal_query* query, rasqal_data_graphs_set* data_graphs);
 
 RASQAL_API
 void* rasqal_query_get_user_data(rasqal_query* query);

--- a/src/rasqal_data_graphs_set.c
+++ b/src/rasqal_data_graphs_set.c
@@ -73,14 +73,14 @@ rasqal_data_graphs_set_new(void)
 }
 
 /**
- * rasqal_data_graphs_set_free:
+ * rasqal_free_data_graphs_set:
  * @set: #rasqal_data_graphs_set object
  *
  * Destructor - destroy a rasqal_data_graphs_set.
  *
  **/
 void
-rasqal_data_graphs_set_free(rasqal_data_graphs_set* set)
+rasqal_free_data_graphs_set(rasqal_data_graphs_set* set)
 {
   if(!set)
     return;

--- a/src/rasqal_data_graphs_set.c
+++ b/src/rasqal_data_graphs_set.c
@@ -98,7 +98,7 @@ rasqal_free_data_graphs_set(rasqal_data_graphs_set* set)
  *
  * In the current implementation no check is made that the graph
  * is added only once. So duplicate graphs may be added to the same set.
- * It is however possibly that the future implementation would not
+ * It is however possible that the future implementation would not
  * add a graph which is already in the set.
  *
  * Return value: non-0 on failure
@@ -120,7 +120,7 @@ rasqal_data_graphs_set_add_data_graph(rasqal_data_graphs_set* set, rasqal_data_g
  *
  * In the current implementation no check is made that the graph
  * is added only once. So duplicate graphs may be added to the same set.
- * It is however possibly that the future implementation would not
+ * It is however possible that the future implementation would not
  * add a graph which is already in the set.
  *
  * Return value: non-0 on failure

--- a/src/rasqal_data_graphs_set.c
+++ b/src/rasqal_data_graphs_set.c
@@ -151,6 +151,26 @@ rasqal_data_graphs_set_get_data_graph_sequence(rasqal_data_graphs_set* set)
 }
 
 /**
+ * rasqal_data_graphs_get_graphs_count:
+ * @set: #rasqal_data_graphs_set object
+ *
+ * Gets the count of all graphs in the set.
+ *
+ * WARNING: In a future version we may prevent adding the same graph more
+ * than once, what may lead to the count of graphs being less than the number
+ * of times a graph was added.
+ *
+ * Return value: the count of the graphs
+ **/
+int
+rasqal_data_graphs_get_graphs_count(rasqal_data_graphs_set* set)
+{
+  RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(set, rasqal_data_graphs_set, -1);
+
+  return raptor_sequence_size(set->seq);
+}
+
+/**
  * rasqal_data_graphs_set_get_data_graph:
  * @set: #rasqal_data_graphs_set object
  * @idx: #int index

--- a/src/rasqal_data_graphs_set.c
+++ b/src/rasqal_data_graphs_set.c
@@ -46,6 +46,13 @@
 #include "rasqal_internal.h"
 
 
+/**
+ * rasqal_data_graphs_set_new:
+ *
+ * Constructor - create a new graphs set.
+ *
+ * Return value: a new graphs set object or NULL on failure
+ **/
 rasqal_data_graphs_set*
 rasqal_data_graphs_set_new(void)
 {
@@ -65,6 +72,13 @@ rasqal_data_graphs_set_new(void)
   return set;
 }
 
+/**
+ * rasqal_data_graphs_set_free:
+ * @set: #rasqal_data_graphs_set object
+ *
+ * Destructor - destroy a rasqal_data_graphs_set.
+ *
+ **/
 void
 rasqal_data_graphs_set_free(rasqal_data_graphs_set* set)
 {
@@ -75,6 +89,20 @@ rasqal_data_graphs_set_free(rasqal_data_graphs_set* set)
   RASQAL_FREE(rasqal_data_graphs_set, set);
 }
 
+/**
+ * rasqal_data_graphs_set_add_data_graph:
+ * @set: #rasqal_data_graphs_set object
+ * @data_graph: #rasqal_data_graph object
+ *
+ * Adds a data graph to the set.
+ *
+ * In the current implementation no check is made that the graph
+ * is added only once. So duplicate graphs may be added to the same set.
+ * It is however possibly that the future implementation would not
+ * add a graph which is already in the set.
+ *
+ * Return value: non-0 on failure
+ **/
 int
 rasqal_data_graphs_set_add_data_graph(rasqal_data_graphs_set* set, rasqal_data_graph* data_graph)
 {
@@ -83,6 +111,20 @@ rasqal_data_graphs_set_add_data_graph(rasqal_data_graphs_set* set, rasqal_data_g
   return raptor_sequence_push(set->seq, data_graph);
 }
 
+/**
+ * rasqal_data_graphs_set_add_data_graphs:
+ * @set: #rasqal_data_graphs_set object
+ * @raptor_sequence: #raptor_sequence object
+ *
+ * Adds zero or more data graphs to the set.
+ *
+ * In the current implementation no check is made that the graph
+ * is added only once. So duplicate graphs may be added to the same set.
+ * It is however possibly that the future implementation would not
+ * add a graph which is already in the set.
+ *
+ * Return value: non-0 on failure
+ **/
 int
 rasqal_data_graphs_set_add_data_graphs(rasqal_data_graphs_set* set, raptor_sequence* data_graphs)
 {
@@ -92,6 +134,14 @@ rasqal_data_graphs_set_add_data_graphs(rasqal_data_graphs_set* set, raptor_seque
   return raptor_sequence_join(set->seq, data_graphs);
 }
 
+/**
+ * rasqal_data_graphs_set_get_data_graph_sequence:
+ * @set: #rasqal_data_graphs_set object
+ *
+ * Gets the sequence of all graphs in the set.
+ *
+ * Return value: the sequence
+ **/
 raptor_sequence*
 rasqal_data_graphs_set_get_data_graph_sequence(rasqal_data_graphs_set* set)
 {
@@ -100,6 +150,20 @@ rasqal_data_graphs_set_get_data_graph_sequence(rasqal_data_graphs_set* set)
   return set->seq;
 }
 
+/**
+ * rasqal_data_graphs_set_get_data_graph:
+ * @set: #rasqal_data_graphs_set object
+ * @idx: #int index
+ *
+ * Gets the N-th graph in the set.
+ *
+ * WARNING: In the current version the order of the graphs is the same as the
+ * order they were added in. But in a future version the order of the graphs
+ * may change, and adding the same graph more than once may be equivalent to
+ * adding it just once.
+ *
+ * Return value: the graph.
+ **/
 rasqal_data_graph*
 rasqal_data_graphs_set_get_data_graph(rasqal_data_graphs_set* set, int idx)
 {
@@ -108,6 +172,15 @@ rasqal_data_graphs_set_get_data_graph(rasqal_data_graphs_set* set, int idx)
   return (rasqal_data_graph*)raptor_sequence_get_at(set->seq, idx);
 }
 
+/**
+ * rasqal_data_graphs_set_get_data_graph:
+ * @set: #rasqal_data_graphs_set object
+ * @graph_uri: #raptor_uri URI
+ *
+ * Checks if the graphs set contains a named graph.
+ *
+ * Return value: non-0 if true
+ **/
 int
 rasqal_data_graphs_set_dataset_contains_named_graph(rasqal_data_graphs_set* set, raptor_uri *graph_uri)
 {

--- a/src/rasqal_data_graphs_set.c
+++ b/src/rasqal_data_graphs_set.c
@@ -1,0 +1,129 @@
+/* -*- Mode: c; c-basic-offset: 2 -*-
+ *
+ * rasqal_data_graphs_set.c - Rasqal RDF Data Graps Set
+ *
+ * Copyright (C) 2017, Victor Porton http://portonvictor.org
+ *
+ * This package is Free Software and part of Redland http://librdf.org/
+ *
+ * It is licensed under the following three licenses as alternatives:
+ *   1. GNU Lesser General Public License (LGPL) V2.1 or any newer version
+ *   2. GNU General Public License (GPL) V2 or any newer version
+ *   3. Apache License, V2.0 or any newer version
+ *
+ * You may not use this file except in compliance with at least one of
+ * the above three licenses.
+ *
+ * See LICENSE.html or LICENSE.txt at the top of this package for the
+ * complete terms and further detail along with the license texts for
+ * the licenses in COPYING.LIB, COPYING and LICENSE-2.0.txt respectively.
+ *
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <rasqal_config.h>
+#endif
+
+#ifdef WIN32
+#include <win32_rasqal_config.h>
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <stdarg.h>
+
+#include "rasqal.h"
+#include "rasqal_internal.h"
+
+
+rasqal_data_graphs_set*
+rasqal_data_graphs_set_new(void)
+{
+  raptor_sequence* seq;
+  rasqal_data_graphs_set* set;
+
+  seq = raptor_new_sequence((raptor_data_free_handler)rasqal_free_data_graph, (raptor_data_print_handler)rasqal_data_graph_print);
+  if(!seq)
+    return NULL;
+
+  set = RASQAL_CALLOC(rasqal_data_graphs_set*, 1, sizeof(*set));
+  if(!set)
+    return NULL;
+
+  set->seq = seq;
+
+  return set;
+}
+
+void
+rasqal_data_graphs_set_free(rasqal_data_graphs_set* set)
+{
+  if(!set)
+    return;
+
+  raptor_free_sequence(set->seq);
+  RASQAL_FREE(rasqal_data_graphs_set, set);
+}
+
+int
+rasqal_data_graphs_set_add_data_graph(rasqal_data_graphs_set* set, rasqal_data_graph* data_graph)
+{
+  RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(set, rasqal_data_graphs_set, NULL);
+
+  return raptor_sequence_push(set->seq, data_graph);
+}
+
+int
+rasqal_data_graphs_set_add_data_graphs(rasqal_data_graphs_set* set, raptor_sequence* data_graphs)
+{
+  RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(set, rasqal_data_graphs_set, 1);
+  RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(data_graphs, raptor_sequence, 1);
+
+  return raptor_sequence_join(set->seq, data_graphs);
+}
+
+raptor_sequence*
+rasqal_data_graphs_set_get_data_graph_sequence(rasqal_data_graphs_set* set)
+{
+  RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(set, rasqal_data_graphs_set, 1);
+
+  return set->seq;
+}
+
+rasqal_data_graph*
+rasqal_data_graphs_set_get_data_graph(rasqal_data_graphs_set* set, int idx)
+{
+  RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(set, rasqal_data_graphs_set, 1);
+
+  return (rasqal_data_graph*)raptor_sequence_get_at(set->seq, idx);
+}
+
+int
+rasqal_data_graphs_set_dataset_contains_named_graph(rasqal_data_graphs_set* set, raptor_uri *graph_uri)
+{
+  rasqal_data_graph *dg;
+  int idx;
+  int found = 0;
+
+  RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(set, rasqal_data_graphs_set, 1);
+  RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(graph_uri, raptor_uri, 1);
+
+  for(idx = 0; (dg = rasqal_data_graphs_set_get_data_graph(set, idx)); idx++) {
+    if(dg->name_uri && raptor_uri_equals(dg->name_uri, graph_uri)) {
+      /* graph_uri is a graph name in the dataset */
+      found = 1;
+      break;
+    }
+  }
+  return found;
+}

--- a/src/rasqal_internal.h
+++ b/src/rasqal_internal.h
@@ -4,21 +4,21 @@
  *
  * Copyright (C) 2003-2010, David Beckett http://www.dajobe.org/
  * Copyright (C) 2003-2005, University of Bristol, UK http://www.bristol.ac.uk/
- * 
+ *
  * This package is Free Software and part of Redland http://librdf.org/
- * 
+ *
  * It is licensed under the following three licenses as alternatives:
  *   1. GNU Lesser General Public License (LGPL) V2.1 or any newer version
  *   2. GNU General Public License (GPL) V2 or any newer version
  *   3. Apache License, V2.0 or any newer version
- * 
+ *
  * You may not use this file except in compliance with at least one of
  * the above three licenses.
- * 
+ *
  * See LICENSE.html or LICENSE.txt at the top of this package for the
  * complete terms and further detail along with the license texts for
  * the licenses in COPYING.LIB, COPYING and LICENSE-2.0.txt respectively.
- * 
+ *
  */
 
 
@@ -50,7 +50,7 @@ extern "C" {
 #endif
 
 #ifdef __GNUC__
-#define RASQAL_NORETURN __attribute__((noreturn)) 
+#define RASQAL_NORETURN __attribute__((noreturn))
 #else
 #define RASQAL_NORETURN
 #endif
@@ -70,7 +70,7 @@ void* rasqal_sign_malloc(size_t size);
 void* rasqal_sign_calloc(size_t nmemb, size_t size);
 void* rasqal_sign_realloc(void *ptr, size_t size);
 void rasqal_sign_free(void *ptr);
-  
+
 #define RASQAL_MALLOC(type, size)   (type)rasqal_sign_malloc(size)
 #define RASQAL_CALLOC(type, nmemb, size) (type)rasqal_sign_calloc(nmemb, size)
 #define RASQAL_REALLOC(type, ptr, size) (type0rasqal_sign_realloc(ptr, size)
@@ -141,8 +141,8 @@ void rasqal_system_free(void *ptr);
 
 #ifdef RASQAL_DISABLE_ASSERT
 
-#define RASQAL_ASSERT(condition, msg) 
-#define RASQAL_ASSERT_RETURN(condition, msg, ret) 
+#define RASQAL_ASSERT(condition, msg)
+#define RASQAL_ASSERT_RETURN(condition, msg, ret)
 #define RASQAL_ASSERT_OBJECT_POINTER_RETURN(pointer, type) do { \
   if(!pointer) \
     return; \
@@ -227,13 +227,13 @@ typedef struct rasqal_query_language_factory_s rasqal_query_language_factory;
  */
 typedef struct {
   rasqal_query* query;
-  
+
   raptor_sequence* variables;
 
   unsigned int wildcard:1;
 
   int distinct;
-} rasqal_projection;  
+} rasqal_projection;
 
 
 /**
@@ -250,13 +250,13 @@ typedef struct {
  */
 typedef struct {
   rasqal_query* query;
-  
+
   raptor_sequence* order_conditions;
 
   raptor_sequence* group_conditions;
 
   raptor_sequence* having_conditions;
-  
+
   int limit;
 
   int offset;
@@ -275,13 +275,13 @@ typedef struct {
 typedef struct {
   /* usage/reference count */
   int usage;
-  
+
   rasqal_query* query;
-  
+
   raptor_sequence* variables;
 
   raptor_sequence* rows;
-} rasqal_bindings;  
+} rasqal_bindings;
 
 
 /*
@@ -292,7 +292,7 @@ struct rasqal_graph_pattern_s {
 
   /* operator for this graph pattern's contents */
   rasqal_graph_pattern_operator op;
-  
+
   raptor_sequence* triples;          /* ... rasqal_triple*         */
   raptor_sequence* graph_patterns;   /* ... rasqal_graph_pattern*  */
 
@@ -330,7 +330,7 @@ struct rasqal_graph_pattern_s {
 rasqal_graph_pattern* rasqal_new_basic_graph_pattern(rasqal_query* query, raptor_sequence* triples, int start_column, int end_column);
 rasqal_graph_pattern* rasqal_new_graph_pattern_from_sequence(rasqal_query* query, raptor_sequence* graph_patterns, rasqal_graph_pattern_operator op);
 rasqal_graph_pattern* rasqal_new_filter_graph_pattern(rasqal_query* query, rasqal_expression* expr);
-rasqal_graph_pattern* rasqal_new_let_graph_pattern(rasqal_query *query, rasqal_variable *var, rasqal_expression *expr);  
+rasqal_graph_pattern* rasqal_new_let_graph_pattern(rasqal_query *query, rasqal_variable *var, rasqal_expression *expr);
 rasqal_graph_pattern* rasqal_new_select_graph_pattern(rasqal_query *query, rasqal_projection* projection, raptor_sequence* data_graphs, rasqal_graph_pattern* where, rasqal_solution_modifier* modifier, rasqal_bindings* bindings);
 rasqal_graph_pattern* rasqal_new_single_graph_pattern(rasqal_query* query, rasqal_graph_pattern_operator op, rasqal_graph_pattern* single);
 rasqal_graph_pattern* rasqal_new_values_graph_pattern(rasqal_query* query, rasqal_bindings* bindings);
@@ -407,7 +407,7 @@ struct rasqal_query_s {
   rasqal_world* world; /* world object */
 
   int usage; /* reference count - 1 for itself, plus for query_results */
-  
+
   unsigned char* query_string;
   size_t query_string_length; /* length including NULs */
 
@@ -415,7 +415,7 @@ struct rasqal_query_s {
 
   /* query graph pattern, containing the sequence of graph_patterns below */
   rasqal_graph_pattern* query_graph_pattern;
-  
+
   /* the query verb - in SPARQL terms: SELECT, CONSTRUCT, DESCRIBE or ASK */
   rasqal_query_verb verb;
 
@@ -424,8 +424,8 @@ struct rasqal_query_s {
 
   /* sequences of ... */
   raptor_sequence* data_graphs; /* ... rasqal_data_graph*          */
-  /* NOTE: Cannot assume that triples are in any of 
-   * graph pattern use / query execution / document order 
+  /* NOTE: Cannot assume that triples are in any of
+   * graph pattern use / query execution / document order
    */
   raptor_sequence* triples;     /* ... rasqal_triple*              */
   raptor_sequence* prefixes;    /* ... rasqal_prefix*              */
@@ -505,7 +505,7 @@ struct rasqal_query_s {
 
   /* Number of graph patterns in this query */
   int graph_pattern_count;
-  
+
   /* Graph pattern shared pointers by gp index (after prepare) */
   raptor_sequence* graph_patterns_sequence;
 
@@ -546,7 +546,7 @@ struct rasqal_query_s {
 
   /* WAS: sequence of (group by ...) having condition expressions */
   raptor_sequence* unused8;
-  
+
   /* INTERNAL solution modifier */
   rasqal_solution_modifier* modifier;
 
@@ -573,25 +573,25 @@ struct rasqal_query_s {
  */
 struct rasqal_query_language_factory_s {
   rasqal_world* world;
-  
+
   struct rasqal_query_language_factory_s* next;
 
   /* static description that the query language registration initialises */
   raptor_syntax_description desc;
-  
+
   /* the rest of this structure is populated by the
      query-language-specific register function */
   size_t context_length;
-  
+
   /* create a new query */
   int (*init)(rasqal_query* rq, const char *name);
-  
+
   /* destroy a query */
   void (*terminate)(rasqal_query* rq);
-  
+
   /* prepare a query */
   int (*prepare)(rasqal_query* rq);
-  
+
   /* finish the query language factory */
   void (*finish_factory)(rasqal_query_language_factory* factory);
 
@@ -696,7 +696,7 @@ rasqal_rowsource* rasqal_new_slice_rowsource(rasqal_world *world, rasqal_query *
 
 /* rasqal_rowsource_service.c */
 rasqal_rowsource* rasqal_new_service_rowsource(rasqal_world *world, rasqal_query* query, raptor_uri* service_uri, const unsigned char* query_string, raptor_sequence* data_graphs, unsigned int rs_flags);
-  
+
 /* rasqal_rowsource_sort.c */
 rasqal_rowsource* rasqal_new_sort_rowsource(rasqal_world *world, rasqal_query *query, rasqal_rowsource *rowsource, raptor_sequence* order_seq, int distinct);
 
@@ -825,7 +825,7 @@ typedef int (*rasqal_rowsource_set_origin_func) (rasqal_rowsource* rowsource, vo
  * @set_origin: set origin (GRAPH) handler - optional (V1)
  *
  * Row Source implementation factory handler structure.
- * 
+ *
  */
 typedef struct {
   int version;
@@ -870,7 +870,7 @@ typedef struct {
 typedef struct rasqal_results_compare_s rasqal_results_compare;
 
 
-/* 
+/*
  * Rowsource Internal flags
  *
  * RASQAL_ROWSOURCE_FLAGS_SAVE_ROWS: need to save all rows in
@@ -906,7 +906,7 @@ typedef struct rasqal_results_compare_s rasqal_results_compare;
  * @variables_sequence contains the ordered projection of the
  * variables for the columns for this row sequence, from the full set
  * of variables in @vars_table.
- * 
+ *
  * Each row has @size #rasqal_literal values for the variables or
  * NULL if unset.
  *
@@ -919,7 +919,7 @@ typedef struct rasqal_results_compare_s rasqal_results_compare;
  * rasqal_rowsource_get_rows_count() returns the current number of
  * rows that have been read which is only useful in the read one row
  * case.
- * 
+ *
  * The variables associated with a rowsource can be read by
  * rasqal_rowsource_get_variable_by_offset() and
  * rasqal_rowsource_get_variable_offset_by_name() which all are
@@ -935,9 +935,9 @@ struct rasqal_rowsource_s
   rasqal_world* world;
 
   rasqal_query* query;
-  
+
   int flags;
-  
+
   void *user_data;
 
   const rasqal_rowsource_handler* handler;
@@ -951,7 +951,7 @@ struct rasqal_rowsource_s
   rasqal_variables_table* vars_table;
 
   raptor_sequence* variables_sequence;
-  
+
   int size;
 
   raptor_sequence* rows_sequence;
@@ -1018,7 +1018,7 @@ struct rasqal_query_results_format_factory_s {
 
   /* Memory to allocate for per-formatter data */
   int context_length;
-  
+
   /* format initialisation (OPTIONAL) */
   rasqal_query_results_init_func init;
 
@@ -1147,13 +1147,13 @@ rasqal_graph_pattern* rasqal_graph_pattern_get_parent(rasqal_query *query, rasqa
 
 
 /* sparql_parser.y */
-typedef struct 
+typedef struct
 {
   raptor_uri* uri;
   rasqal_update_graph_applies applies;
 } sparql_uri_applies;
 
-typedef struct 
+typedef struct
 {
   rasqal_op op;
   rasqal_expression *expr;
@@ -1346,7 +1346,7 @@ void* rasqal_map_search(rasqal_map* map, const void* key);
 
 
 /* rasqal_query.c */
-rasqal_query_results* rasqal_query_execute_with_engine(rasqal_query* query, const rasqal_query_execution_factory* engine);
+rasqal_query_results* rasqal_query_execute_with_engine(rasqal_query* query, raptor_sequence* data_graphs, const rasqal_query_execution_factory* engine);
 int rasqal_query_remove_query_result(rasqal_query* query, rasqal_query_results* query_results);
 int rasqal_query_declare_prefix(rasqal_query* rq, rasqal_prefix* prefix);
 int rasqal_query_declare_prefixes(rasqal_query* rq);
@@ -1364,7 +1364,7 @@ int rasqal_query_set_modifier(rasqal_query* query, rasqal_solution_modifier* mod
 /* rasqal_query_results.c */
 int rasqal_init_query_results(void);
 void rasqal_finish_query_results(void);
-int rasqal_query_results_execute_with_engine(rasqal_query_results* query_results, const rasqal_query_execution_factory* factory, int store_results);
+int rasqal_query_results_execute_with_engine(rasqal_query_results* query_results, const rasqal_query_execution_factory* factory, raptor_sequence* data_graphs, int store_results);
 int rasqal_query_check_limit_offset_core(int result_offset, int limit, int offset);
 int rasqal_query_check_limit_offset(rasqal_query* query, int result_offset);
 void rasqal_query_results_remove_query_reference(rasqal_query_results* query_results);
@@ -1431,7 +1431,7 @@ int rasqal_row_compatible_check(rasqal_row_compatible* map, rasqal_row *first_ro
 void rasqal_print_row_compatible(FILE *handle, rasqal_row_compatible* map);
 
 /* rasqal_triples_source.c */
-rasqal_triples_source* rasqal_new_triples_source(rasqal_query* query);
+rasqal_triples_source* rasqal_new_triples_source(rasqal_query* query, raptor_sequence* data_graphs);
 int rasqal_reset_triple_meta(rasqal_triple_meta* m);
 void rasqal_free_triples_source(rasqal_triples_source *rts);
 int rasqal_triples_source_triple_present(rasqal_triples_source *rts, rasqal_triple *t);
@@ -1467,7 +1467,7 @@ typedef struct rasqal_graph_factory_s rasqal_graph_factory;
 struct rasqal_world_s {
   /* opened flag */
   int opened;
-  
+
   /* raptor_world object */
   raptor_world *raptor_world_ptr;
 
@@ -1574,7 +1574,7 @@ struct rasqal_algebra_node_s {
   raptor_sequence* triples;
   int start_column;
   int end_column;
-  
+
   /* types JOIN, DIFF, LEFTJOIN, UNION, ORDERBY: node1 and node2 ALWAYS present
    * types FILTER, TOLIST: node1 ALWAYS present, node2 ALWAYS NULL
    * type PROJECT, GRAPH, GROUPBY, AGGREGATION, HAVING: node1 always present
@@ -1584,7 +1584,7 @@ struct rasqal_algebra_node_s {
   struct rasqal_algebra_node_s *node2;
 
   /* types FILTER, LEFTJOIN
-   * (otherwise NULL) 
+   * (otherwise NULL)
    */
   rasqal_expression* expr;
 
@@ -1643,7 +1643,7 @@ typedef int (*rasqal_algebra_node_visit_fn)(rasqal_query* query, rasqal_algebra_
 typedef struct
 {
   rasqal_query* query;
-  
+
   /* aggregate expression variables map
    * key: rasqal_expression* tree with an aggregate function at top
    * value: rasqal_variable*
@@ -1759,7 +1759,7 @@ struct rasqal_query_execution_factory_s {
 
   /* size of execution engine private data */
   size_t execution_data_size;
-  
+
   /*
    * @ex_data: execution data
    * @query: query to execute
@@ -1771,7 +1771,7 @@ struct rasqal_query_execution_factory_s {
    *
    * Return value: non-0 on failure
    */
-  int (*execute_init)(void* ex_data, rasqal_query* query, rasqal_query_results* query_results, int flags, rasqal_engine_error *error_p);
+  int (*execute_init)(void* ex_data, rasqal_query* query, rasqal_query_results* query_results, raptor_sequence* data_graphs, int flags, rasqal_engine_error *error_p);
 
   /**
    * @ex_data: execution data
@@ -1787,7 +1787,7 @@ struct rasqal_query_execution_factory_s {
    * @ex_data: execution object
    * @error_p: execution error (OUT variable)
    *
-   * Get current bindings result row (returning a new object) 
+   * Get current bindings result row (returning a new object)
    *
    * Will not be called if query results is NULL, finished or failed.
    */
@@ -1795,7 +1795,7 @@ struct rasqal_query_execution_factory_s {
 
   /* finish (free) execution */
   int (*execute_finish)(void* ex_data, rasqal_engine_error *error_p);
-  
+
   /* finish the query execution factory */
   void (*finish_factory)(rasqal_query_execution_factory* factory);
 
@@ -1884,7 +1884,7 @@ int rasqal_triples_sequence_set_origin(raptor_sequence* dest_seq, raptor_sequenc
  * RASQAL_RANDOM_STATE_SIZE:
  *
  * Size of BSD random state
- * 
+ *
  * "With 256 bytes of state information, the period of the random
  * number generator is greater than 2**69 , which should be
  * sufficient for most purposes." - BSD random(3) man page

--- a/src/rasqal_internal.h
+++ b/src/rasqal_internal.h
@@ -1351,7 +1351,7 @@ void* rasqal_map_search(rasqal_map* map, const void* key);
 
 
 /* rasqal_query.c */
-rasqal_query_results* rasqal_query_execute_with_engine(rasqal_query* query, raptor_sequence* data_graphs, const rasqal_query_execution_factory* engine);
+rasqal_query_results* rasqal_query_execute_with_engine(rasqal_query* query, rasqal_data_graphs_set* data_graphs, const rasqal_query_execution_factory* engine);
 int rasqal_query_remove_query_result(rasqal_query* query, rasqal_query_results* query_results);
 int rasqal_query_declare_prefix(rasqal_query* rq, rasqal_prefix* prefix);
 int rasqal_query_declare_prefixes(rasqal_query* rq);
@@ -1369,7 +1369,7 @@ int rasqal_query_set_modifier(rasqal_query* query, rasqal_solution_modifier* mod
 /* rasqal_query_results.c */
 int rasqal_init_query_results(void);
 void rasqal_finish_query_results(void);
-int rasqal_query_results_execute_with_engine(rasqal_query_results* query_results, const rasqal_query_execution_factory* factory, raptor_sequence* data_graphs, int store_results);
+int rasqal_query_results_execute_with_engine(rasqal_query_results* query_results, const rasqal_query_execution_factory* factory, rasqal_data_graphs_set* data_graphs, int store_results);
 int rasqal_query_check_limit_offset_core(int result_offset, int limit, int offset);
 int rasqal_query_check_limit_offset(rasqal_query* query, int result_offset);
 void rasqal_query_results_remove_query_reference(rasqal_query_results* query_results);

--- a/src/rasqal_internal.h
+++ b/src/rasqal_internal.h
@@ -216,6 +216,11 @@ typedef struct rasqal_query_execution_factory_s rasqal_query_execution_factory;
 typedef struct rasqal_query_language_factory_s rasqal_query_language_factory;
 
 
+struct rasqal_data_graphs_set_s {
+  raptor_sequence* seq;
+};
+
+
 /**
  * rasqal_projection:
  * @query: rasqal query

--- a/src/rasqal_query.c
+++ b/src/rasqal_query.c
@@ -588,10 +588,13 @@ rasqal_query_set_offset(rasqal_query* query, int offset)
  * Add a data graph to the query.
  *
  * Return value: non-0 on failure
+ *
+ * @Deprecated: Use rasqal_query_execute2() instead.
  **/
 int
 rasqal_query_add_data_graph(rasqal_query* query, rasqal_data_graph* data_graph)
 {
+  RASQAL_DEPRECATED_MESSAGE("rasqal_query_add_data_graph");
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, 1);
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(data_graph, rasqal_data_graph, 1);
 
@@ -612,12 +615,16 @@ rasqal_query_add_data_graph(rasqal_query* query, rasqal_data_graph* data_graph)
  * The @data_graphs sequence itself is freed and must not be used after this call.
  *
  * Return value: non-0 on failure
+ *
+ * @Deprecated: Use rasqal_query_execute2() instead.
  **/
 int
 rasqal_query_add_data_graphs(rasqal_query* query,
                              raptor_sequence* data_graphs)
 {
   int rc;
+
+  RASQAL_DEPRECATED_MESSAGE("rasqal_query_add_data_graphs");
 
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, 1);
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(data_graphs, raptor_sequence, 1);
@@ -636,10 +643,13 @@ rasqal_query_add_data_graphs(rasqal_query* query,
  * Get the sequence of data_graph URIs.
  *
  * Return value: a #raptor_sequence of #raptor_uri pointers.
+ *
+ * @Deprecated: Use rasqal_query_execute2() instead.
  **/
 raptor_sequence*
 rasqal_query_get_data_graph_sequence(rasqal_query* query)
 {
+  RASQAL_DEPRECATED_MESSAGE("rasqal_query_get_data_graph_sequence");
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, NULL);
 
   return query->data_graphs;
@@ -654,6 +664,8 @@ rasqal_query_get_data_graph_sequence(rasqal_query* query)
  * Get a rasqal_data_graph* in the sequence of data_graphs.
  *
  * Return value: a #rasqal_data_graph pointer or NULL if out of the sequence range
+ *
+ * @Deprecated: Use rasqal_query_execute2() instead.
  **/
 rasqal_data_graph*
 rasqal_query_get_data_graph(rasqal_query* query, int idx)
@@ -675,6 +687,8 @@ rasqal_query_get_data_graph(rasqal_query* query, int idx)
  * Test if the query dataset contains a named graph
  *
  * Return value: non-0 if the dataset contains a named graph
+ *
+ * TODO: Reimplement with data graphs argument.
  */
 int
 rasqal_query_dataset_contains_named_graph(rasqal_query* query,
@@ -1416,6 +1430,8 @@ rasqal_query_execute(rasqal_query* query)
 rasqal_query_results*
 rasqal_query_execute2(rasqal_query* query, raptor_sequence* data_graphs)
 {
+  RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(data_graphs, raptor_sequence, NULL);
+
   return rasqal_query_execute_with_engine(query, data_graphs, NULL);
 }
 

--- a/src/rasqal_query.c
+++ b/src/rasqal_query.c
@@ -4,22 +4,22 @@
  *
  * Copyright (C) 2003-2009, David Beckett http://www.dajobe.org/
  * Copyright (C) 2003-2005, University of Bristol, UK http://www.bristol.ac.uk/
- * 
+ *
  * This package is Free Software and part of Redland http://librdf.org/
- * 
+ *
  * It is licensed under the following three licenses as alternatives:
  *   1. GNU Lesser General Public License (LGPL) V2.1 or any newer version
  *   2. GNU General Public License (GPL) V2 or any newer version
  *   3. Apache License, V2.0 or any newer version
- * 
+ *
  * You may not use this file except in compliance with at least one of
  * the above three licenses.
- * 
+ *
  * See LICENSE.html or LICENSE.txt at the top of this package for the
  * complete terms and further detail along with the license texts for
  * the licenses in COPYING.LIB, COPYING and LICENSE-2.0.txt respectively.
- * 
- * 
+ *
+ *
  */
 
 #ifdef HAVE_CONFIG_H
@@ -110,18 +110,18 @@ rasqal_new_query(rasqal_world *world, const char *name,
   query = RASQAL_CALLOC(rasqal_query*, 1, sizeof(*query));
   if(!query)
     return NULL;
-  
+
   /* set usage first to 1 so we can clean up with rasqal_free_query() on error */
   query->usage = 1;
 
   query->world = world;
-  
+
   query->factory = factory;
 
   query->context = RASQAL_CALLOC(void*, 1, factory->context_length);
   if(!query->context)
     goto tidy;
-  
+
   query->namespaces = raptor_new_namespaces(world->raptor_world_ptr, 0);
   if(!query->namespaces)
     goto tidy;
@@ -154,7 +154,7 @@ rasqal_new_query(rasqal_world *world, const char *name,
 
   if(factory->init(query, name))
     goto tidy;
-  
+
   return query;
 
   tidy:
@@ -167,18 +167,18 @@ rasqal_new_query(rasqal_world *world, const char *name,
 /**
  * rasqal_free_query:
  * @query: #rasqal_query object
- * 
+ *
  * Destructor - destroy a #rasqal_query object.
  **/
 void
-rasqal_free_query(rasqal_query* query) 
+rasqal_free_query(rasqal_query* query)
 {
   if(!query)
     return;
-  
+
   if(--query->usage)
     return;
-  
+
   if(query->factory)
     query->factory->terminate(query);
 
@@ -238,13 +238,13 @@ rasqal_free_query(rasqal_query* query)
 
   if(query->modifier)
     rasqal_free_solution_modifier(query->modifier);
-  
+
   if(query->bindings)
     rasqal_free_bindings(query->bindings);
-  
+
   if(query->projection)
     rasqal_free_projection(query->projection);
-  
+
   RASQAL_FREE(rasqal_query, query);
 }
 
@@ -292,7 +292,7 @@ rasqal_query_get_label(rasqal_query* query)
  * @value: integer feature value
  *
  * Set various query features.
- * 
+ *
  * The allowed features are available via rasqal_features_enumerate().
  *
  * Return value: non 0 on failure or if the feature is unknown
@@ -308,7 +308,7 @@ rasqal_query_set_feature(rasqal_query* query, rasqal_feature feature, int value)
 
       if(feature == RASQAL_FEATURE_RAND_SEED)
         query->user_set_rand = 1;
-      
+
       query->features[RASQAL_GOOD_CAST(int, feature)] = value;
       break;
   }
@@ -324,15 +324,15 @@ rasqal_query_set_feature(rasqal_query* query, rasqal_feature feature, int value)
  * @value: feature value
  *
  * Set query features with string values.
- * 
+ *
  * The allowed features are available via rasqal_features_enumerate().
  * If the feature type is integer, the value is interpreted as an integer.
  *
  * Return value: non 0 on failure or if the feature is unknown
  **/
 int
-rasqal_query_set_feature_string(rasqal_query *query, 
-                                rasqal_feature feature, 
+rasqal_query_set_feature_string(rasqal_query *query,
+                                rasqal_feature feature,
                                 const unsigned char *value)
 {
   int value_is_string = (rasqal_feature_value_type(feature) == 1);
@@ -353,7 +353,7 @@ rasqal_query_set_feature_string(rasqal_query *query,
  * @feature: feature to get value
  *
  * Get various query features.
- * 
+ *
  * The allowed features are available via rasqal_features_enumerate().
  *
  * Note: no feature value is negative
@@ -364,7 +364,7 @@ int
 rasqal_query_get_feature(rasqal_query *query, rasqal_feature feature)
 {
   int result= -1;
-  
+
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, 1);
 
   switch(feature) {
@@ -373,7 +373,7 @@ rasqal_query_get_feature(rasqal_query *query, rasqal_feature feature)
       result = (query->features[RASQAL_GOOD_CAST(int, feature)] != 0);
       break;
   }
-  
+
   return result;
 }
 
@@ -384,14 +384,14 @@ rasqal_query_get_feature(rasqal_query *query, rasqal_feature feature)
  * @feature: feature to get value
  *
  * Get query features with string values.
- * 
+ *
  * The allowed features are available via rasqal_features_enumerate().
  * If a string is returned, it must be freed by the caller.
  *
  * Return value: feature value or NULL for an illegal feature or no value
  **/
 const unsigned char *
-rasqal_query_get_feature_string(rasqal_query *query, 
+rasqal_query_get_feature_string(rasqal_query *query,
                                 rasqal_feature feature)
 {
   int value_is_string = (rasqal_feature_value_type(feature) == 1);
@@ -400,7 +400,7 @@ rasqal_query_get_feature_string(rasqal_query *query,
 
   if(!value_is_string)
     return NULL;
-  
+
   return NULL;
 }
 
@@ -422,7 +422,7 @@ rasqal_query_get_distinct(rasqal_query* query)
 
   if(!query->projection)
     return 0;
-  
+
   return query->projection->distinct;
 }
 
@@ -437,7 +437,7 @@ rasqal_query_get_distinct(rasqal_query* query)
  * The allowed @distinct_mode values are:
  * 0 if not given
  * 1 if DISTINCT: ensure solutions are unique
- * 2 if SPARQL REDUCED: permit elimination of some non-unique solutions 
+ * 2 if SPARQL REDUCED: permit elimination of some non-unique solutions
  *
  **/
 void
@@ -618,7 +618,7 @@ rasqal_query_add_data_graphs(rasqal_query* query,
                              raptor_sequence* data_graphs)
 {
   int rc;
-  
+
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, 1);
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(data_graphs, raptor_sequence, 1);
 
@@ -662,7 +662,7 @@ rasqal_query_get_data_graph(rasqal_query* query, int idx)
 
   if(!query->data_graphs)
     return NULL;
-  
+
   return (rasqal_data_graph*)raptor_sequence_get_at(query->data_graphs, idx);
 }
 
@@ -683,7 +683,7 @@ rasqal_query_dataset_contains_named_graph(rasqal_query* query,
   rasqal_data_graph *dg;
   int idx;
   int found = 0;
-  
+
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, 1);
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(graph_uri, raptor_uri, 1);
 
@@ -751,7 +751,7 @@ rasqal_query_get_bound_variable_sequence(rasqal_query* query)
 
   if(!query->projection)
     return NULL;
-  
+
   return rasqal_projection_get_variables_sequence(query->projection);
 }
 
@@ -966,7 +966,7 @@ rasqal_query_get_triple(rasqal_query* query, int idx)
 
   if(!query->triples)
     return NULL;
-  
+
   return (rasqal_triple*)raptor_sequence_get_at(query->triples, idx);
 }
 
@@ -980,8 +980,8 @@ rasqal_query_declare_prefix(rasqal_query *rq, rasqal_prefix *p)
   if(p->declared)
     return 0;
 
-  if(raptor_namespaces_start_namespace_full(rq->namespaces, 
-                                            p->prefix, 
+  if(raptor_namespaces_start_namespace_full(rq->namespaces,
+                                            p->prefix,
                                             raptor_uri_as_string(p->uri),
                                             rq->prefix_depth))
     return 1;
@@ -1001,22 +1001,22 @@ rasqal_query_undeclare_prefix(rasqal_query *rq, rasqal_prefix *prefix)
     prefix->declared = 1;
     return 0;
   }
-  
+
   raptor_namespaces_end_for_depth(rq->namespaces, prefix->depth);
   return 0;
 }
 
 
 int
-rasqal_query_declare_prefixes(rasqal_query *rq) 
+rasqal_query_declare_prefixes(rasqal_query *rq)
 {
   int i;
-  
+
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(rq, rasqal_query, 1);
 
   if(!rq->prefixes)
     return 0;
-  
+
   for(i = 0; i< raptor_sequence_size(rq->prefixes); i++) {
     rasqal_prefix* p = (rasqal_prefix*)raptor_sequence_get_at(rq->prefixes, i);
     if(rasqal_query_declare_prefix(rq, p))
@@ -1205,7 +1205,7 @@ rasqal_query_get_construct_triple(rasqal_query* query, int idx)
  * @base_uri: base URI of query string (optional)
  *
  * Prepare a query - typically parse it.
- * 
+ *
  * Some query languages may require a base URI to resolve any
  * relative URIs in the query string.  If this is not given,
  * the current directory in the filesystem is used as the base URI.
@@ -1222,7 +1222,7 @@ rasqal_query_prepare(rasqal_query* query,
                      raptor_uri *base_uri)
 {
   int rc = 0;
-  
+
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, 1);
 
   if(query->failed)
@@ -1237,7 +1237,7 @@ rasqal_query_prepare(rasqal_query* query,
   if(query_string) {
     /* flex lexers require two NULs at the end of the lexed buffer.
      * Add them here instead of parser to allow resource cleanup on error.
-     *  
+     *
      * flex manual:
      *
      * Function: YY_BUFFER_STATE yy_scan_buffer (char *base, yy_size_t size)
@@ -1286,10 +1286,10 @@ rasqal_query_prepare(rasqal_query* query,
       seed = RASQAL_GOOD_CAST(unsigned int, query->features[RASQAL_GOOD_CAST(int, RASQAL_FEATURE_RAND_SEED)]);
     else
       seed = rasqal_random_get_system_seed(query->world);
-    
+
     rasqal_evaluation_context_set_rand_seed(query->eval_context, seed);
   }
-  
+
 
   rc = query->factory->prepare(query);
   if(rc) {
@@ -1314,7 +1314,7 @@ rasqal_query_prepare(rasqal_query* query,
  *
  * return value: pointer to factory
  **/
-const rasqal_query_execution_factory* 
+const rasqal_query_execution_factory*
 rasqal_query_get_engine_by_name(const char* name)
 {
   const rasqal_query_execution_factory* engine;
@@ -1344,11 +1344,12 @@ rasqal_query_get_engine_by_name(const char* name)
  **/
 rasqal_query_results*
 rasqal_query_execute_with_engine(rasqal_query* query,
+                                 raptor_sequence* data_graphs,
                                  const rasqal_query_execution_factory* engine)
 {
   rasqal_query_results *query_results = NULL;
   rasqal_query_results_type type;
-  
+
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, NULL);
 
   if(query->failed)
@@ -1357,7 +1358,7 @@ rasqal_query_execute_with_engine(rasqal_query* query,
   type = rasqal_query_get_result_type(query);
   if(type == RASQAL_QUERY_RESULTS_UNKNOWN)
     return NULL;
-  
+
   query_results = rasqal_new_query_results2(query->world, query, type);
   if(!query_results)
     return NULL;
@@ -1365,16 +1366,16 @@ rasqal_query_execute_with_engine(rasqal_query* query,
   if(!engine)
     engine = rasqal_query_get_engine_by_name(NULL);
 
-  if(rasqal_query_results_execute_with_engine(query_results, engine,
+  if(rasqal_query_results_execute_with_engine(query_results, engine, data_graphs,
                                               query->store_results)) {
     rasqal_free_query_results(query_results);
-    query_results = NULL;      
+    query_results = NULL;
   }
-    
-      
+
+
   if(query_results && rasqal_query_add_query_result(query, query_results)) {
     rasqal_free_query_results(query_results);
-    query_results = NULL;      
+    query_results = NULL;
   }
 
   return query_results;
@@ -1385,14 +1386,37 @@ rasqal_query_execute_with_engine(rasqal_query* query,
  * rasqal_query_execute:
  * @query: the #rasqal_query object
  *
- * Excute a query - run and return results.
+ * Execute a query - run and return results.
  *
  * return value: a #rasqal_query_results structure or NULL on failure.
+ *
+ * This is deprecated in favor of rasqal_query_execute2().
  **/
 rasqal_query_results*
 rasqal_query_execute(rasqal_query* query)
 {
-  return rasqal_query_execute_with_engine(query, NULL);
+  RASQAL_DEPRECATED_MESSAGE("rasqal_query_execute");
+  return rasqal_query_execute_with_engine(query, NULL, NULL);
+}
+
+
+/**
+ * rasqal_query_execute2:
+ * @query: the #rasqal_query object
+ * @data_graphs: a datagraphs set
+ *
+ * Execute a query over a dataset - run and return results.
+ *
+ * return value: a #rasqal_query_results structure or NULL on failure.
+ *
+ * This API is experimental:
+ * In the current API version @data_graphs is a sequence of graphs.
+ * It may be something other in a future version.
+ **/
+rasqal_query_results*
+rasqal_query_execute2(rasqal_query* query, raptor_sequence* data_graphs)
+{
+  return rasqal_query_execute_with_engine(query, data_graphs, NULL);
 }
 
 
@@ -1414,19 +1438,19 @@ static const char* const rasqal_query_verb_labels[RASQAL_QUERY_VERB_LAST+1] = {
  * @verb: the #rasqal_query_verb verb of the query
  *
  * Get a string for the query verb.
- * 
+ *
  * Return value: pointer to a shared string label for the query verb
  **/
 const char*
 rasqal_query_verb_as_string(rasqal_query_verb verb)
 {
-  if(verb <= RASQAL_QUERY_VERB_UNKNOWN || 
+  if(verb <= RASQAL_QUERY_VERB_UNKNOWN ||
      verb > RASQAL_QUERY_VERB_LAST)
     verb = RASQAL_QUERY_VERB_UNKNOWN;
 
   return rasqal_query_verb_labels[RASQAL_GOOD_CAST(int, verb)];
 }
-  
+
 
 /**
  * rasqal_query_print:
@@ -1434,7 +1458,7 @@ rasqal_query_verb_as_string(rasqal_query_verb verb)
  * @fh: the FILE* handle to print to.
  *
  * Print a query in a debug format.
- * 
+ *
  * Return value: non-0 on failure
  **/
 int
@@ -1448,7 +1472,7 @@ rasqal_query_print(rasqal_query* query, FILE *fh)
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(fh, FILE*, 1);
 
   fprintf(fh, "query verb: %s\n", rasqal_query_verb_as_string(query->verb));
-  
+
   distinct_mode = rasqal_query_get_distinct(query);
   if(distinct_mode)
     fprintf(fh, "query results distinct mode: %s\n",
@@ -1462,24 +1486,24 @@ rasqal_query_print(rasqal_query* query, FILE *fh)
     if(query->modifier->offset > 0)
       fprintf(fh, "query results offset: %d\n", query->modifier->offset);
   }
-  
+
   fputs("data graphs: ", fh);
   if(query->data_graphs)
     raptor_sequence_print(query->data_graphs, fh);
   seq = rasqal_variables_table_get_named_variables_sequence(vars_table);
   if(seq) {
-    fputs("\nnamed variables: ", fh); 
+    fputs("\nnamed variables: ", fh);
     raptor_sequence_print(seq, fh);
   }
   seq = rasqal_variables_table_get_anonymous_variables_sequence(vars_table);
   if(seq) {
-    fputs("\nanonymous variables: ", fh); 
+    fputs("\nanonymous variables: ", fh);
     raptor_sequence_print(seq, fh);
   }
   seq = rasqal_query_get_bound_variable_sequence(query);
   if(seq) {
     int i;
-    
+
     fputs("\nprojected variable names: ", fh);
     for(i = 0; 1; i++) {
       rasqal_variable* v = (rasqal_variable*)raptor_sequence_get_at(seq, i);
@@ -1491,8 +1515,8 @@ rasqal_query_print(rasqal_query* query, FILE *fh)
       fputs((const char*)v->name, fh);
     }
     fputc('\n', fh);
-      
-    fputs("\nbound variables: ", fh); 
+
+    fputs("\nbound variables: ", fh);
     raptor_sequence_print(seq, fh);
   }
   if(query->describes) {
@@ -1534,7 +1558,7 @@ rasqal_query_print(rasqal_query* query, FILE *fh)
       raptor_sequence_print(query->modifier->having_conditions, fh);
     }
   }
-  
+
   if(query->updates) {
     fputs("\nupdate operations: ", fh);
     raptor_sequence_print(query->updates, fh);
@@ -1551,7 +1575,7 @@ rasqal_query_print(rasqal_query* query, FILE *fh)
 
 static int
 rasqal_query_add_query_result(rasqal_query* query,
-                              rasqal_query_results* query_results) 
+                              rasqal_query_results* query_results)
 {
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, 1);
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query_results, rasqal_query_results, 1);
@@ -1561,7 +1585,7 @@ rasqal_query_add_query_result(rasqal_query* query,
   /* query->results sequence has rasqal_query_results_remove_query_reference()
      as the free handler which calls rasqal_free_query() decrementing
      query->usage */
-  
+
   query->usage++;
 
   return raptor_sequence_push(query->results, query_results);
@@ -1571,11 +1595,11 @@ rasqal_query_add_query_result(rasqal_query* query,
 
 int
 rasqal_query_remove_query_result(rasqal_query* query,
-                                 rasqal_query_results* query_results) 
+                                 rasqal_query_results* query_results)
 {
   int i;
   int size;
-  
+
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, 1);
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query_results, rasqal_query_results, 1);
 
@@ -1600,7 +1624,7 @@ rasqal_query_remove_query_result(rasqal_query* query,
  * @query: #rasqal_query
  *
  * Get query user data.
- * 
+ *
  * Return value: user data as set by rasqal_query_set_user_data()
  **/
 void*
@@ -1661,7 +1685,7 @@ rasqal_query_get_wildcard(rasqal_query* query)
 
   if(!query->projection)
     return 0;
-  
+
   return query->projection->wildcard;
 }
 
@@ -1727,7 +1751,7 @@ rasqal_query_get_order_condition(rasqal_query* query, int idx)
 
   if(!query->modifier || !query->modifier->order_conditions)
     return NULL;
-  
+
   return (rasqal_expression*)raptor_sequence_get_at(query->modifier->order_conditions, idx);
 }
 
@@ -1768,7 +1792,7 @@ rasqal_query_get_group_condition(rasqal_query* query, int idx)
 
    if(!query->modifier || !query->modifier->group_conditions)
     return NULL;
-  
+
   return (rasqal_expression*)raptor_sequence_get_at(query->modifier->group_conditions, idx);
 }
 
@@ -1809,7 +1833,7 @@ rasqal_query_get_having_condition(rasqal_query* query, int idx)
 
    if(!query->modifier || !query->modifier->having_conditions)
     return NULL;
-  
+
   return (rasqal_expression*)raptor_sequence_get_at(query->modifier->having_conditions, idx);
 }
 
@@ -1819,7 +1843,7 @@ rasqal_query_get_having_condition(rasqal_query* query, int idx)
  * @query: query
  * @visit_fn: user function to operate on
  * @data: user data to pass to function
- * 
+ *
  * Visit all graph patterns in a query with a user function @visit_fn.
  *
  * See also rasqal_graph_pattern_visit().
@@ -1827,8 +1851,8 @@ rasqal_query_get_having_condition(rasqal_query* query, int idx)
  * Return value: result from visit function @visit_fn if it returns non-0
  **/
 int
-rasqal_query_graph_pattern_visit2(rasqal_query* query, 
-                                  rasqal_graph_pattern_visit_fn visit_fn, 
+rasqal_query_graph_pattern_visit2(rasqal_query* query,
+                                  rasqal_graph_pattern_visit_fn visit_fn,
                                   void* data)
 {
   rasqal_graph_pattern* gp;
@@ -1849,7 +1873,7 @@ rasqal_query_graph_pattern_visit2(rasqal_query* query,
  * @query: query
  * @visit_fn: user function to operate on
  * @data: user data to pass to function
- * 
+ *
  * Visit all graph patterns in a query with a user function @visit_fn.
  *
  * @Deprecated: use rasqal_query_graph_pattern_visit2() that returns the @visit_fn status code.
@@ -1857,8 +1881,8 @@ rasqal_query_graph_pattern_visit2(rasqal_query* query,
  * See also rasqal_graph_pattern_visit().
  **/
 void
-rasqal_query_graph_pattern_visit(rasqal_query* query, 
-                                 rasqal_graph_pattern_visit_fn visit_fn, 
+rasqal_query_graph_pattern_visit(rasqal_query* query,
+                                 rasqal_graph_pattern_visit_fn visit_fn,
                                  void* data)
 {
   (void)rasqal_query_graph_pattern_visit2(query, visit_fn, data);
@@ -1874,7 +1898,7 @@ rasqal_query_graph_pattern_visit(rasqal_query* query,
  * @base_uri: #raptor_uri base URI of the output format
  *
  * Write a query to an iostream in a specified format.
- * 
+ *
  * The supported URIs for the format_uri are:
  *
  * Default: SPARQL Query Language 2006-04-06
@@ -1913,9 +1937,9 @@ rasqal_query_write(raptor_iostream* iostr, rasqal_query* query,
  * @iostr: #raptor_iostream to write the escaped string to
  * @string: string to escape
  * @len: Length of string to escape
- * 
+ *
  * Write a string to an iostream in escaped form suitable for the query string.
- * 
+ *
  * Return value: non-0 on failure
  **/
 int
@@ -1929,7 +1953,7 @@ rasqal_query_iostream_write_escaped_counted_string(rasqal_query* query,
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(string, char*, 1);
 
   if(query->factory->iostream_write_escaped_counted_string)
-    return query->factory->iostream_write_escaped_counted_string(query, iostr, 
+    return query->factory->iostream_write_escaped_counted_string(query, iostr,
                                                                  string, len);
   else
     return 1;
@@ -1942,9 +1966,9 @@ rasqal_query_iostream_write_escaped_counted_string(rasqal_query* query,
  * @string: string to escape
  * @len: Length of string to escape
  * @output_len_p: Pointer to store length of output string (or NULL)
- * 
+ *
  * Convert a string into an escaped form suitable for the query string.
- * 
+ *
  * The returned string must be freed by the caller with
  * rasqal_free_memory()
  *
@@ -1952,14 +1976,14 @@ rasqal_query_iostream_write_escaped_counted_string(rasqal_query* query,
  **/
 unsigned char*
 rasqal_query_escape_counted_string(rasqal_query* query,
-                                   const unsigned char* string, 
+                                   const unsigned char* string,
                                    size_t len,
                                    size_t* output_len_p)
 {
   raptor_iostream* iostr;
   void* output_string = NULL;
   int rc;
-  
+
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, NULL);
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(string, char*, NULL);
 
@@ -1975,7 +1999,7 @@ rasqal_query_escape_counted_string(rasqal_query* query,
     rasqal_free_memory(output_string);
     output_string = NULL;
   }
-  
+
   return (unsigned char *)output_string;
 }
 
@@ -1999,7 +2023,7 @@ rasqal_query_set_base_uri(rasqal_query* query, raptor_uri* base_uri)
  * @store_results: store results flag
  *
  * Request that query results are stored during execution
- * 
+ *
  * When called after a rasqal_query_prepare(), this tells
  * rasqal_query_execute() to execute the entire query immediately
  * rather than generate them lazily, and store all the results in
@@ -2024,7 +2048,7 @@ rasqal_query_set_store_results(rasqal_query* query, int store_results)
 }
 
 
-rasqal_variable* 
+rasqal_variable*
 rasqal_query_get_variable_by_offset(rasqal_query* query, int idx)
 {
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, NULL);
@@ -2045,7 +2069,7 @@ rasqal_query_get_variable_by_offset(rasqal_query* query, int idx)
  * Return value: non-0 on failure
  **/
 int
-rasqal_query_add_update_operation(rasqal_query* query, 
+rasqal_query_add_update_operation(rasqal_query* query,
                                   rasqal_update_operation *update)
 {
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, 1);
@@ -2100,7 +2124,7 @@ rasqal_query_get_update_operation(rasqal_query* query, int idx)
 
   if(!query->updates)
     return NULL;
-  
+
   return (rasqal_update_operation*)raptor_sequence_get_at(query->updates, idx);
 }
 
@@ -2138,7 +2162,7 @@ rasqal_query_get_bindings_variables_sequence(rasqal_query* query)
     return query->bindings->variables;
   else
     return NULL;
-  
+
 }
 
 
@@ -2158,7 +2182,7 @@ rasqal_query_get_bindings_variable(rasqal_query* query, int idx)
 
   if(!query->bindings || !query->bindings->variables)
     return NULL;
-  
+
   return (rasqal_variable*)raptor_sequence_get_at(query->bindings->variables, idx);
 }
 
@@ -2180,7 +2204,7 @@ rasqal_query_get_bindings_rows_sequence(rasqal_query* query)
     return query->bindings->rows;
   else
     return NULL;
-  
+
 }
 
 
@@ -2200,7 +2224,7 @@ rasqal_query_get_bindings_row(rasqal_query* query, int idx)
 
   if(!query->bindings || !query->bindings->rows)
     return NULL;
-  
+
   return (rasqal_row*)raptor_sequence_get_at(query->bindings->rows, idx);
 }
 
@@ -2210,7 +2234,7 @@ rasqal_query_get_bindings_row(rasqal_query* query, int idx)
  * @query: #rasqal_query query object
  * @variable: variable
  * @column: triple column
- * 
+ *
  * INTERNAL - Test if variable is bound in given triple
  *
  * Return value: part of triple the variable is bound in
@@ -2222,9 +2246,9 @@ rasqal_query_variable_bound_in_triple(rasqal_query* query,
 {
   int width;
   unsigned short *triple_row;
-  
+
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, (rasqal_triple_parts)0);
-  
+
   width = rasqal_variables_table_get_total_variables_count(query->vars_table);
   triple_row = &query->triples_use_map[column * width];
 
@@ -2270,7 +2294,7 @@ rasqal_query_get_result_type(rasqal_query* query)
       case RASQAL_QUERY_VERB_DESCRIBE:
         type = RASQAL_QUERY_RESULTS_GRAPH;
         break;
-        
+
       case RASQAL_QUERY_VERB_UNKNOWN:
       case RASQAL_QUERY_VERB_DELETE:
       case RASQAL_QUERY_VERB_INSERT:
@@ -2310,7 +2334,7 @@ rasqal_query_store_select_query(rasqal_query* query,
   rasqal_query_set_projection(query, projection);
 
   query->query_graph_pattern = where_gp;
-  
+
   if(data_graphs)
     rasqal_query_add_data_graphs(query, data_graphs);
 
@@ -2378,7 +2402,7 @@ rasqal_query_set_projection(rasqal_query* query, rasqal_projection* projection)
     rasqal_free_projection(query->projection);
 
   query->projection = projection;
-  
+
   return 0;
 }
 
@@ -2402,6 +2426,6 @@ rasqal_query_set_modifier(rasqal_query* query,
     rasqal_free_solution_modifier(query->modifier);
 
   query->modifier = modifier;
-  
+
   return 0;
 }

--- a/src/rasqal_query.c
+++ b/src/rasqal_query.c
@@ -594,7 +594,6 @@ rasqal_query_set_offset(rasqal_query* query, int offset)
 int
 rasqal_query_add_data_graph(rasqal_query* query, rasqal_data_graph* data_graph)
 {
-  RASQAL_DEPRECATED_MESSAGE("rasqal_query_add_data_graph");
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, 1);
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(data_graph, rasqal_data_graph, 1);
 
@@ -624,8 +623,6 @@ rasqal_query_add_data_graphs(rasqal_query* query,
 {
   int rc;
 
-  RASQAL_DEPRECATED_MESSAGE("rasqal_query_add_data_graphs");
-
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, 1);
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(data_graphs, raptor_sequence, 1);
 
@@ -649,7 +646,6 @@ rasqal_query_add_data_graphs(rasqal_query* query,
 raptor_sequence*
 rasqal_query_get_data_graph_sequence(rasqal_query* query)
 {
-  RASQAL_DEPRECATED_MESSAGE("rasqal_query_get_data_graph_sequence");
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query, rasqal_query, NULL);
 
   return query->data_graphs;
@@ -1409,7 +1405,6 @@ rasqal_query_execute_with_engine(rasqal_query* query,
 rasqal_query_results*
 rasqal_query_execute(rasqal_query* query)
 {
-  RASQAL_DEPRECATED_MESSAGE("rasqal_query_execute");
   return rasqal_query_execute_with_engine(query, NULL, NULL);
 }
 

--- a/src/rasqal_query.c
+++ b/src/rasqal_query.c
@@ -583,7 +583,7 @@ rasqal_query_set_offset(rasqal_query* query, int offset)
 /**
  * rasqal_query_add_data_graph:
  * @query: #rasqal_query query object
- * @data_graph: data graph
+ * @data_graph: #rasqal_data_graph data graph
  *
  * Add a data graph to the query.
  *
@@ -1354,7 +1354,7 @@ rasqal_query_get_engine_by_name(const char* name)
  **/
 rasqal_query_results*
 rasqal_query_execute_with_engine(rasqal_query* query,
-                                 raptor_sequence* data_graphs,
+                                 rasqal_data_graphs_set* data_graphs,
                                  const rasqal_query_execution_factory* engine)
 {
   rasqal_query_results *query_results = NULL;
@@ -1412,20 +1412,16 @@ rasqal_query_execute(rasqal_query* query)
 /**
  * rasqal_query_execute2:
  * @query: the #rasqal_query object
- * @data_graphs: a datagraphs set
+ * @data_graphs: #rasqal_data_graphs_set a datagraphs set
  *
  * Execute a query over a dataset - run and return results.
  *
  * return value: a #rasqal_query_results structure or NULL on failure.
- *
- * This API is experimental:
- * In the current API version @data_graphs is a sequence of graphs.
- * It may be something other in a future version.
  **/
 rasqal_query_results*
-rasqal_query_execute2(rasqal_query* query, raptor_sequence* data_graphs)
+rasqal_query_execute2(rasqal_query* query, rasqal_data_graphs_set* data_graphs)
 {
-  RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(data_graphs, raptor_sequence, NULL);
+  RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(data_graphs, rasqal_data_graphs_set, NULL);
 
   return rasqal_query_execute_with_engine(query, data_graphs, NULL);
 }

--- a/src/rasqal_query_results.c
+++ b/src/rasqal_query_results.c
@@ -358,7 +358,7 @@ rasqal_new_query_results_from_string(rasqal_world* world,
 int
 rasqal_query_results_execute_with_engine(rasqal_query_results* query_results,
                                          const rasqal_query_execution_factory* engine,
-                                         raptor_sequence* data_graphs,
+                                         rasqal_data_graphs_set* data_graphs,
                                          int store_results)
 {
   int rc = 0;
@@ -402,7 +402,7 @@ rasqal_query_results_execute_with_engine(rasqal_query_results* query_results,
     if(query_results->store_results)
       execution_flags |= 1;
 
-    rc = query_results->execution_factory->execute_init(query_results->execution_data, query, query_results, data_graphs, execution_flags, &execution_error);
+    rc = query_results->execution_factory->execute_init(query_results->execution_data, query, query_results, data_graphs->seq, execution_flags, &execution_error);
 
     if(rc || execution_error != RASQAL_ENGINE_OK) {
       query_results->failed = 1;

--- a/src/rasqal_query_results.c
+++ b/src/rasqal_query_results.c
@@ -364,6 +364,7 @@ rasqal_query_results_execute_with_engine(rasqal_query_results* query_results,
   int rc = 0;
   size_t ex_data_size;
   rasqal_query* query;
+  raptor_sequence* dg_seq;
 
 
   RASQAL_ASSERT_OBJECT_POINTER_RETURN_VALUE(query_results, rasqal_query_results, 1);
@@ -372,6 +373,8 @@ rasqal_query_results_execute_with_engine(rasqal_query_results* query_results,
 
   if(query->failed)
     return 1;
+
+  dg_seq = data_graphs ? data_graphs->seq : query->data_graphs;
 
   query_results->execution_factory = engine;
 
@@ -402,7 +405,7 @@ rasqal_query_results_execute_with_engine(rasqal_query_results* query_results,
     if(query_results->store_results)
       execution_flags |= 1;
 
-    rc = query_results->execution_factory->execute_init(query_results->execution_data, query, query_results, data_graphs->seq, execution_flags, &execution_error);
+    rc = query_results->execution_factory->execute_init(query_results->execution_data, query, query_results, dg_seq, execution_flags, &execution_error);
 
     if(rc || execution_error != RASQAL_ENGINE_OK) {
       query_results->failed = 1;

--- a/src/rasqal_rowsource_triples.c
+++ b/src/rasqal_rowsource_triples.c
@@ -3,21 +3,21 @@
  * rasqal_rowsource_triples.c - Rasqal triple pattern rowsource class
  *
  * Copyright (C) 2008-2009, David Beckett http://www.dajobe.org/
- * 
+ *
  * This package is Free Software and part of Redland http://librdf.org/
- * 
+ *
  * It is licensed under the following three licenses as alternatives:
  *   1. GNU Lesser General Public License (LGPL) V2.1 or any newer version
  *   2. GNU General Public License (GPL) V2 or any newer version
  *   3. Apache License, V2.0 or any newer version
- * 
+ *
  * You may not use this file except in compliance with at least one of
  * the above three licenses.
- * 
+ *
  * See LICENSE.html or LICENSE.txt at the top of this package for the
  * complete terms and further detail along with the license texts for
  * the licenses in COPYING.LIB, COPYING and LICENSE-2.0.txt respectively.
- * 
+ *
  */
 
 
@@ -43,7 +43,7 @@
 
 #ifndef STANDALONE
 
-typedef struct 
+typedef struct
 {
   /* source of triple pattern matches */
   rasqal_triples_source* triples_source;
@@ -63,16 +63,16 @@ typedef struct
   /* number of triple patterns in the sequence
      ( = end_column - start_column + 1) */
   int triples_count;
-  
+
   /* An array of items, one per triple pattern in the sequence */
   rasqal_triple_meta* triple_meta;
 
   /* offset into results for current row */
   int offset;
-  
+
   /* number of variables used in variables table  */
   int size;
-  
+
   /* GRAPH origin to use */
   rasqal_literal *origin;
 } rasqal_triples_rowsource_context;
@@ -87,17 +87,17 @@ rasqal_triples_rowsource_init(rasqal_rowsource* rowsource, void *user_data)
   int rc = 0;
   int size;
   int i;
-  
+
   con = (rasqal_triples_rowsource_context*)user_data;
 
   size = rasqal_variables_table_get_total_variables_count(query->vars_table);
-  
+
   /* Construct the ordered projection of the variables set by these triples */
   con->size = 0;
   for(i = 0; i < size; i++) {
     rasqal_variable *v;
     v = rasqal_variables_table_get(rowsource->vars_table, i);
-    
+
     for(column = con->start_column; column <= con->end_column; column++) {
       if(rasqal_query_variable_bound_in_triple(query, v, column)) {
           v = rasqal_new_variable_from_variable(v);
@@ -121,15 +121,15 @@ rasqal_triples_rowsource_init(rasqal_rowsource* rowsource, void *user_data)
     m->parts = (rasqal_triple_parts)0;
 
     t = (rasqal_triple*)raptor_sequence_get_at(con->triples, column);
-    
+
     if((v = rasqal_literal_as_variable(t->subject)) &&
        rasqal_query_variable_bound_in_triple(query, v, column) & RASQAL_TRIPLE_SUBJECT)
       m->parts = (rasqal_triple_parts)(m->parts | RASQAL_TRIPLE_SUBJECT);
-    
+
     if((v = rasqal_literal_as_variable(t->predicate)) &&
        rasqal_query_variable_bound_in_triple(query, v, column) & RASQAL_TRIPLE_PREDICATE)
       m->parts = (rasqal_triple_parts)(m->parts | RASQAL_TRIPLE_PREDICATE);
-    
+
     if((v = rasqal_literal_as_variable(t->object)) &&
        rasqal_query_variable_bound_in_triple(query, v, column) & RASQAL_TRIPLE_OBJECT)
       m->parts = (rasqal_triple_parts)(m->parts | RASQAL_TRIPLE_OBJECT);
@@ -138,7 +138,7 @@ rasqal_triples_rowsource_init(rasqal_rowsource* rowsource, void *user_data)
                   rasqal_engine_get_parts_string(m->parts), m->parts);
 
   }
-  
+
   return rc;
 }
 
@@ -148,10 +148,10 @@ rasqal_triples_rowsource_ensure_variables(rasqal_rowsource* rowsource,
                                           void *user_data)
 {
   rasqal_triples_rowsource_context* con;
-  con = (rasqal_triples_rowsource_context*)user_data; 
+  con = (rasqal_triples_rowsource_context*)user_data;
 
   rowsource->size = con->size;
-  
+
   return 0;
 }
 
@@ -161,7 +161,7 @@ rasqal_triples_rowsource_finish(rasqal_rowsource* rowsource, void *user_data)
 {
   rasqal_triples_rowsource_context *con;
   int i;
-  
+
   con = (rasqal_triples_rowsource_context*)user_data;
 
   if(con->triple_meta) {
@@ -184,12 +184,12 @@ rasqal_triples_rowsource_finish(rasqal_rowsource* rowsource, void *user_data)
 
 
 static rasqal_engine_error
-rasqal_triples_rowsource_get_next_row(rasqal_rowsource* rowsource, 
+rasqal_triples_rowsource_get_next_row(rasqal_rowsource* rowsource,
                                       rasqal_triples_rowsource_context *con)
 {
   rasqal_query *query = rowsource->query;
   rasqal_engine_error error = RASQAL_ENGINE_OK;
-  
+
   while(con->column >= con->start_column) {
     rasqal_triple_meta *m;
     rasqal_triple *t;
@@ -244,7 +244,7 @@ rasqal_triples_rowsource_get_next_row(rasqal_rowsource* rowsource,
     }
 
     rasqal_triples_match_next_match(m->triples_match);
-    
+
     if(con->column == con->end_column)
       /* finished matching all columns - return result */
       break;
@@ -264,7 +264,7 @@ rasqal_triples_rowsource_read_row(rasqal_rowsource* rowsource, void *user_data)
   int i;
   rasqal_row* row = NULL;
   rasqal_engine_error error = RASQAL_ENGINE_OK;
-  
+
   con = (rasqal_triples_rowsource_context*)user_data;
 
   error = rasqal_triples_rowsource_get_next_row(rowsource, con);
@@ -315,7 +315,7 @@ rasqal_triples_rowsource_read_all_rows(rasqal_rowsource* rowsource,
                                        void *user_data)
 {
   raptor_sequence *seq = NULL;
-  
+
   return seq;
 }
 
@@ -325,13 +325,13 @@ rasqal_triples_rowsource_reset(rasqal_rowsource* rowsource, void *user_data)
 {
   rasqal_triples_rowsource_context *con;
   int column;
-  
+
   con = (rasqal_triples_rowsource_context*)user_data;
 
   con->column = con->start_column;
   for(column = con->start_column; column <= con->end_column; column++) {
     rasqal_triple_meta *m;
-    
+
     m = &con->triple_meta[column - con->start_column];
     rasqal_reset_triple_meta(m);
   }
@@ -360,7 +360,7 @@ rasqal_triples_rowsource_set_origin(rasqal_rowsource *rowsource,
       rasqal_free_literal(t->origin);
     t->origin = rasqal_new_literal_from_literal(con->origin);
   }
-  
+
   return 0;
 }
 
@@ -409,7 +409,7 @@ rasqal_new_triples_rowsource(rasqal_world *world,
 
   if(!triples)
     return rasqal_new_empty_rowsource(world, query);
-  
+
   con = RASQAL_CALLOC(rasqal_triples_rowsource_context*, 1, sizeof(*con));
   if(!con)
     return NULL;
@@ -454,7 +454,7 @@ WHERE { ?s ?p ?o }\
 "
 
 int
-main(int argc, char *argv[]) 
+main(int argc, char *argv[])
 {
   const char *program = rasqal_basename(argv[0]);
   rasqal_rowsource *rowsource = NULL;
@@ -480,7 +480,7 @@ main(int argc, char *argv[])
   raptor_uri* p_uri = NULL;
   const char *data_file;
   size_t qs_len;
-  
+
   if((data_file = getenv("NT_DATA_FILE"))) {
     /* got data from environment */
   } else {
@@ -490,15 +490,15 @@ main(int argc, char *argv[])
     }
     data_file = argv[1];
   }
-    
+
   world = rasqal_new_world();
   if(!world || rasqal_world_open(world)) {
     fprintf(stderr, "%s: rasqal_world init failed\n", program);
     return(1);
   }
-  
+
   query = rasqal_new_query(world, "sparql", NULL);
-  
+
   data_string = raptor_uri_filename_to_uri_string(data_file);
   qs_len = strlen(RASQAL_GOOD_CAST(const char*, data_string)) + strlen(query_format);
   query_string = RASQAL_MALLOC(unsigned char*, qs_len + 1);
@@ -506,7 +506,7 @@ main(int argc, char *argv[])
   snprintf(RASQAL_GOOD_CAST(char*, query_string), qs_len, query_format, data_string);
   IGNORE_FORMAT_NONLITERAL_END
   raptor_free_memory(data_string);
-  
+
   uri_string = raptor_uri_filename_to_uri_string("");
   base_uri = raptor_new_uri(world->raptor_world_ptr, uri_string);
   raptor_free_memory(uri_string);
@@ -527,7 +527,7 @@ main(int argc, char *argv[])
     failures++;
     goto tidy;
   }
-  
+
   RASQAL_FREE(char*, query_string);
   query_string = NULL;
 
@@ -535,8 +535,8 @@ main(int argc, char *argv[])
   start_column = 0;
   end_column = 0;
 
-  triples_source = rasqal_new_triples_source(query);
-  
+  triples_source = rasqal_new_triples_source(query, query->data_graphs);
+
   rowsource = rasqal_new_triples_rowsource(world, query, triples_source,
                                            triples, start_column, end_column);
   if(!rowsource) {
@@ -554,8 +554,8 @@ main(int argc, char *argv[])
     row = rasqal_rowsource_read_row(rowsource);
     if(!row)
       break;
-    
-  #ifdef RASQAL_DEBUG  
+
+  #ifdef RASQAL_DEBUG
     RASQAL_DEBUG1("Result Row:\n  ");
     rasqal_row_print(row, stderr);
     fputc('\n', stderr);
@@ -563,7 +563,7 @@ main(int argc, char *argv[])
 
     s_uri = raptor_new_uri(world->raptor_world_ptr, SUBJECT_URI_STRING);
     p_uri = raptor_new_uri(world->raptor_world_ptr, PREDICATE_URI_STRING);
-    
+
     s = row->values[0];
     if(!s ||
        (s && s->type != RASQAL_LITERAL_URI) ||

--- a/tests/engine/Makefile.am
+++ b/tests/engine/Makefile.am
@@ -3,25 +3,25 @@
 # Makefile.am - automake file for Rasqal query engine tests
 #
 # Copyright (C) 2004-2008, David Beckett http://www.dajobe.org/
-# 
+#
 # This package is Free Software and part of Redland http://librdf.org/
-# 
+#
 # It is licensed under the following three licenses as alternatives:
 #   1. GNU Lesser General Public License (LGPL) V2.1 or any newer version
 #   2. GNU General Public License (GPL) V2 or any newer version
 #   3. Apache License, V2.0 or any newer version
-# 
+#
 # You may not use this file except in compliance with at least one of
 # the above three licenses.
-# 
+#
 # See LICENSE.html or LICENSE.txt at the top of this package for the
 # complete terms and further detail along with the license texts for
 # the licenses in COPYING.LIB, COPYING and LICENSE-2.0.txt respectively.
-# 
+#
 
 local_tests=rasqal_order_test$(EXEEXT) rasqal_graph_test$(EXEEXT) \
 rasqal_construct_test$(EXEEXT) rasqal_limit_test$(EXEEXT) \
-rasqal_triples_test$(EXEEXT)
+rasqal_triples_test$(EXEEXT) rasqal_execute2_test$(EXEEXT)
 
 EXTRA_PROGRAMS=$(local_tests)
 
@@ -36,6 +36,9 @@ rasqal_order_test_LDADD = $(top_builddir)/src/librasqal.la
 
 rasqal_graph_test_SOURCES = rasqal_graph_test.c
 rasqal_graph_test_LDADD = $(top_builddir)/src/librasqal.la
+
+rasqal_execute2_test_SOURCES = rasqal_execute2_test.c
+rasqal_execute2_test_LDADD = $(top_builddir)/src/librasqal.la
 
 rasqal_construct_test_SOURCES = rasqal_construct_test.c
 rasqal_construct_test_LDADD = $(top_builddir)/src/librasqal.la

--- a/tests/engine/rasqal_execute2_test.c
+++ b/tests/engine/rasqal_execute2_test.c
@@ -148,8 +148,8 @@ main(int argc, char **argv) {
       rasqal_data_graph* dg;
       dg = rasqal_new_data_graph_from_uri(world,
                                           /* source URI */ graph_uris[offset],
-                                          /* name URI */ graph_uris[offset],
-                                          RASQAL_DATA_GRAPH_NAMED,
+                                          /* name URI */ NULL,
+                                          RASQAL_DATA_GRAPH_BACKGROUND,
                                           NULL, NULL, NULL);
       rasqal_data_graphs_set_add_data_graph(graphs_set, dg);
     }

--- a/tests/engine/rasqal_execute2_test.c
+++ b/tests/engine/rasqal_execute2_test.c
@@ -1,0 +1,253 @@
+/* -*- Mode: c; c-basic-offset: 2 -*-
+ *
+ * rasqal_graph_test.c - Rasqal RDF Query GRAPH Tests
+ *
+ * Copyright (C) 2006, David Beckett http://purl.org/net/dajobe/
+ *
+ * This package is Free Software and part of Redland http://librdf.org/
+ *
+ * It is licensed under the following three licenses as alternatives:
+ *   1. GNU Lesser General Public License (LGPL) V2.1 or any newer version
+ *   2. GNU General Public License (GPL) V2 or any newer version
+ *   3. Apache License, V2.0 or any newer version
+ *
+ * You may not use this file except in compliance with at least one of
+ * the above three licenses.
+ *
+ * See LICENSE.html or LICENSE.txt at the top of this package for the
+ * complete terms and further detail along with the license texts for
+ * the licenses in COPYING.LIB, COPYING and LICENSE-2.0.txt respectively.
+ *
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <rasqal_config.h>
+#endif
+
+#ifdef WIN32
+#include <win32_rasqal_config.h>
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+#include <stdarg.h>
+
+#include "rasqal.h"
+#include "rasqal_internal.h"
+
+#ifdef RASQAL_QUERY_SPARQL
+
+
+#define DATA_GRAPH_COUNT 3
+static const char* graph_files[DATA_GRAPH_COUNT] = {
+  "graph-a.ttl",
+  "graph-b.ttl",
+  "graph-c.ttl"
+};
+
+
+#define QUERY_VARIABLES_MAX_COUNT 1
+
+struct test
+{
+  const char *query_language;
+  const char *query_string;
+  /* expected result count */
+  int expected_count;
+  /* data graph offsets (<0 for not used) */
+  int data_graphs[DATA_GRAPH_COUNT];
+  /* expected value answers */
+  const char* value_answers[QUERY_VARIABLES_MAX_COUNT];
+  const char* value_var;
+//   const char* graph_var;
+};
+
+
+
+#define QUERY_COUNT 1
+
+
+static const struct test tests[QUERY_COUNT] = {
+  { /* query_language */ "sparql",
+    /* query_string */ "\
+SELECT (count(*) as ?count) WHERE {\
+   ?s ?p ?o .\
+}",
+    /* expected_count */  1,
+    /* data_graphs */ { 0, 1, 2 },
+    /* value_answers */ { "9" },
+    /* value_var */ "count"
+  }
+};
+
+
+#else
+#define NO_QUERY_LANGUAGE
+#endif
+
+
+#ifdef NO_QUERY_LANGUAGE
+int
+main(int argc, char **argv) {
+  const char *program=rasqal_basename(argv[0]);
+  fprintf(stderr, "%s: No supported query language available, skipping test\n", program);
+  return(0);
+}
+#else
+
+int
+main(int argc, char **argv) {
+  const char *program=rasqal_basename(argv[0]);
+  int failures=0;
+  raptor_uri *base_uri;
+  unsigned char *data_dir_string;
+  raptor_uri* data_dir_uri;
+  unsigned char *uri_string;
+  int i, j;
+  raptor_uri* graph_uris[DATA_GRAPH_COUNT];
+  rasqal_world *world;
+  rasqal_data_graphs_set *graphs_set;
+
+  if(argc != 2) {
+    fprintf(stderr, "USAGE: %s <path to data directory>\n", program);
+    return(1);
+  }
+
+  world=rasqal_new_world();
+  if(!world || rasqal_world_open(world)) {
+    fprintf(stderr, "%s: rasqal_world init failed\n", program);
+    return(1);
+  }
+
+  uri_string=raptor_uri_filename_to_uri_string("");
+  base_uri = raptor_new_uri(world->raptor_world_ptr, uri_string);
+  raptor_free_memory(uri_string);
+
+
+  data_dir_string=raptor_uri_filename_to_uri_string(argv[1]);
+  data_dir_uri = raptor_new_uri(world->raptor_world_ptr, data_dir_string);
+
+  for(i=0; i < DATA_GRAPH_COUNT; i++)
+#ifdef RAPTOR_V2_AVAILABLE
+    graph_uris[i] = raptor_new_uri_relative_to_base(world->raptor_world_ptr,
+                                                    data_dir_uri,
+                                                    (const unsigned char*)graph_files[i]);
+#else
+    graph_uris[i] = raptor_new_uri_relative_to_base(data_dir_uri,
+                                                    (const unsigned char*)graph_files[i]);
+#endif
+
+  graphs_set = rasqal_data_graphs_set_new();
+  for(j=0; j < DATA_GRAPH_COUNT; j++) {
+    int offset=tests[0].data_graphs[j]; /* TODO */
+    if(offset >= 0) {
+      rasqal_data_graph* dg;
+      dg = rasqal_new_data_graph_from_uri(world,
+                                          /* source URI */ graph_uris[offset],
+                                          /* name URI */ graph_uris[offset],
+                                          RASQAL_DATA_GRAPH_NAMED,
+                                          NULL, NULL, NULL);
+      rasqal_data_graphs_set_add_data_graph(graphs_set, dg);
+    }
+  }
+
+  for(i=0; i < QUERY_COUNT; i++) {
+    rasqal_query *query = NULL;
+    rasqal_query_results *results = NULL;
+    const char *query_language_name=tests[i].query_language;
+    const unsigned char *query_string=(const unsigned char *)tests[i].query_string;
+    int count;
+    int query_failed=0;
+
+    query=rasqal_new_query(world, query_language_name, NULL);
+    if(!query) {
+      fprintf(stderr, "%s: creating query %d in language %s FAILED\n",
+              program, i, query_language_name);
+      query_failed=1;
+      goto tidy_query;
+    }
+
+    printf("%s: preparing %s query %d\n", program, query_language_name, i);
+    if(rasqal_query_prepare(query, query_string, base_uri)) {
+      fprintf(stderr, "%s: %s query prepare %d FAILED\n", program,
+              query_language_name, i);
+      query_failed=1;
+      goto tidy_query;
+    }
+
+    printf("%s: executing query %d\n", program, i);
+    results=rasqal_query_execute2(query, graphs_set);
+    if(!results) {
+      fprintf(stderr, "%s: query execution %d FAILED\n", program, i);
+      query_failed=1;
+      goto tidy_query;
+    }
+
+    printf("%s: checking query %d results\n", program, i);
+    count=0;
+    query_failed=0;
+    while(results && !rasqal_query_results_finished(results)) {
+      rasqal_literal *value;
+      rasqal_literal *graph_value;
+      raptor_uri* graph_uri;
+      const char *value_answer=tests[i].value_answers[count];
+//       raptor_uri* graph_answer=graph_uris[tests[i].graph_answers[count]];
+//       const unsigned char* graph_var=(const unsigned char*)tests[i].graph_var;
+      const unsigned char* value_var=(const unsigned char*)tests[i].value_var;
+
+      value=rasqal_query_results_get_binding_value_by_name(results,
+                                                           value_var);
+      if(strcmp((const char*)rasqal_literal_as_string(value), value_answer)) {
+        printf("result %d FAILED: %s=", count, (char*)value_var);
+        rasqal_literal_print(value, stdout);
+        printf(" expected value '%s'\n", value_answer);
+        query_failed=1;
+        break;
+      }
+
+      rasqal_query_results_next(results);
+      count++;
+    }
+    if(results)
+      rasqal_free_query_results(results);
+
+    printf("%s: query %d results count returned %d results\n", program, i,
+           count);
+    if(count != tests[i].expected_count) {
+      printf("%s: query execution %d FAILED returning %d results, expected %d\n",
+             program, i, count, tests[i].expected_count);
+      query_failed=1;
+    }
+
+  tidy_query:
+
+    rasqal_free_query(query);
+    rasqal_free_data_graphs_set(graphs_set);
+
+    if(!query_failed)
+      printf("%s: query %d OK\n", program, i);
+    else {
+      printf("%s: query %d FAILED\n", program, i);
+      failures++;
+    }
+  }
+
+  for(i=0; i < DATA_GRAPH_COUNT; i++) {
+    if(graph_uris[i])
+      raptor_free_uri(graph_uris[i]);
+  }
+  raptor_free_uri(data_dir_uri);
+  raptor_free_memory(data_dir_string);
+
+  raptor_free_uri(base_uri);
+
+  rasqal_free_world(world);
+
+  return failures;
+}
+
+#endif

--- a/tests/engine/rasqal_execute2_test.c
+++ b/tests/engine/rasqal_execute2_test.c
@@ -63,7 +63,6 @@ struct test
   /* expected value answers */
   const char* value_answers[QUERY_VARIABLES_MAX_COUNT];
   const char* value_var;
-//   const char* graph_var;
 };
 
 
@@ -192,11 +191,7 @@ main(int argc, char **argv) {
     query_failed=0;
     while(results && !rasqal_query_results_finished(results)) {
       rasqal_literal *value;
-      rasqal_literal *graph_value;
-      raptor_uri* graph_uri;
       const char *value_answer=tests[i].value_answers[count];
-//       raptor_uri* graph_answer=graph_uris[tests[i].graph_answers[count]];
-//       const unsigned char* graph_var=(const unsigned char*)tests[i].graph_var;
       const unsigned char* value_var=(const unsigned char*)tests[i].value_var;
 
       value=rasqal_query_results_get_binding_value_by_name(results,


### PR DESCRIPTION
I have created Data Graphs objects, which as the name suggests contain several graphs.

I recommend to use my new function `rasqal_query_execute2()` (with such object as an argument) instead of `rasqal_query_execute()` which I deprecated (together with some other functions).

The philosophy is to deprecate strong coupling between a query and a dataset and instead use separate "query" and separate "data set" objects. This allows to execute the same query with more than one different dataset. One advantage is that we no more need to recompile a query to use it with a different dataset.