### PR TITLE
Define printf() before using it in a configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -313,7 +313,8 @@ AC_C_CONST
 AC_C_BIGENDIAN
 
 AC_MSG_CHECKING(whether __FUNCTION__ is available)
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main() { printf(__FUNCTION__); }])],
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([#include <stdio.h>
+                   int main() { printf(__FUNCTION__); }])],
     [AC_DEFINE([HAVE___FUNCTION__], [1], [Is __FUNCTION__ available])
      AC_MSG_RESULT(yes)],
     [AC_MSG_RESULT(no)])


### PR DESCRIPTION
Both clang and GCC will default to treating undefined functions as errors in the near future.