### PR TITLE
configure: Fix incorrect argument type in gcry_md_open

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -771,7 +771,7 @@ elif test "$ac_cv_header_gcrypt_h" = "yes"; then
   LIBS="$LIBS `$LIBGCRYPT_CONFIG --libs`"
 
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include <gcrypt.h>]], [[ gcry_md_hd_t hash; gcry_md_open(hash, GCRY_MD_MD5, 0); ]])],[have_digest_gcrypt=yes],[have_digest_gcrypt=no])
+  #include <gcrypt.h>]], [[ gcry_md_hd_t hash; gcry_md_open(&hash, GCRY_MD_MD5, 0); ]])],[have_digest_gcrypt=yes],[have_digest_gcrypt=no])
 
   CPPFLAGS="$oCPPFLAGS"
   LIBS="$oLIBS"


### PR DESCRIPTION
The `gcry_md_open` function expects a `gcry_md_hd_t *` argument, and not a `gcry_md_hd_t` argument (which is also a pointer behind the typedef).  Future compilers (including GCC 14) will likely treat this as an error, causing the check to fail unconditionally.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
