### PR TITLE
configure: fix libuuid test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -941,7 +941,7 @@ PKG_CHECK_MODULES(UUID, uuid, [
   #if defined(UUID_LEN_BIN) && defined(UUID_VERSION)
   FAIL
   #endif
-  uuid_t data; uuid_clear(&data); ]])],[have_uuid_libuuid=yes],[have_uuid_libuuid=no])
+  uuid_t data; uuid_clear(data); ]])],[have_uuid_libuuid=yes],[have_uuid_libuuid=no])
 
   CPPFLAGS="$oCPPFLAGS"
   LIBS="$oLIBS"


### PR DESCRIPTION
`&data`, where `data` is a `uuid_t`, results in a `unsigned char*`, but `uuid_t` needs to be passed as `unsigned char (*)[16]`, which is a distinct type.  This causes configure to spuriously fail to detect `libuuid`:

```
conftest.c: In function 'main':
conftest.c:74:26: error: passing argument 1 of 'uuid_clear' from incompatible pointer type [-Wincompatible-pointer-types]
   74 |  uuid_t data; uuid_clear(&data);
      |                          ^~~~~
      |                          |
      |                          unsigned char (*)[16]
In file included from conftest.c:70:
/usr/include/uuid/uuid.h:85:31: note: expected 'unsigned char *' but argument is of type 'unsigned char (*)[16]'
   85 | extern void uuid_clear(uuid_t uu);
      |                        ~~~~~~~^~
configure:17809: $? = 1
```